### PR TITLE
fix(mesh): push-context leak, idempotent disconnect, ct-reg leak

### DIFF
--- a/base/Mesh/src/Annium.Mesh.Client/Internal/ClientBase.cs
+++ b/base/Mesh/src/Annium.Mesh.Client/Internal/ClientBase.cs
@@ -354,8 +354,9 @@ internal abstract class ClientBase : IClientBase
         var id = Guid.NewGuid();
         var tcs = new TaskCompletionSource<object>();
         using var cts = new CancellationTokenSource(_configuration.ResponseTimeout.ToTimeSpan());
-        // external token - operation canceled
-        ct.Register(() =>
+        // external token - operation canceled; dispose the registration when the request completes so
+        // callbacks don't accumulate on a long-lived, reused caller token
+        await using var ctRegistration = ct.Register(() =>
         {
             // if not arrived and not expired - cancel
             if (!tcs.Task.IsCompleted && !cts.IsCancellationRequested)

--- a/base/Mesh/src/Annium.Mesh.Server.Web/Internal/Handler.cs
+++ b/base/Mesh/src/Annium.Mesh.Server.Web/Internal/Handler.cs
@@ -2,7 +2,6 @@ using System;
 using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
-using Annium.Core.DependencyInjection;
 using Annium.Logging;
 using Annium.Mesh.Transport.Abstractions;
 using Annium.Net.Servers.Web;
@@ -12,7 +11,7 @@ namespace Annium.Mesh.Server.Web.Internal;
 /// <summary>
 /// Handles incoming WebSocket connections for the mesh server by creating connection wrappers and delegating to the coordinator.
 /// </summary>
-public class Handler : IWebSocketHandler, ILogSubject
+internal class Handler : IWebSocketHandler, ILogSubject
 {
     /// <summary>
     /// Gets the logger for this handler.
@@ -32,12 +31,14 @@ public class Handler : IWebSocketHandler, ILogSubject
     /// <summary>
     /// Initializes a new instance of the <see cref="Handler"/> class.
     /// </summary>
-    /// <param name="sp">The service provider for resolving dependencies.</param>
-    public Handler(IServiceProvider sp)
+    /// <param name="connectionFactory">The factory for creating server connections from WebSockets.</param>
+    /// <param name="coordinator">The coordinator for managing connection lifecycle.</param>
+    /// <param name="logger">The logger for this handler.</param>
+    public Handler(IServerConnectionFactory<WebSocket> connectionFactory, ICoordinator coordinator, ILogger logger)
     {
-        Logger = sp.Resolve<ILogger>();
-        _connectionFactory = sp.Resolve<IServerConnectionFactory<WebSocket>>();
-        _coordinator = sp.Resolve<ICoordinator>();
+        Logger = logger;
+        _connectionFactory = connectionFactory;
+        _coordinator = coordinator;
     }
 
     /// <summary>

--- a/base/Mesh/src/Annium.Mesh.Server/Internal/MessageHandler.cs
+++ b/base/Mesh/src/Annium.Mesh.Server/Internal/MessageHandler.cs
@@ -113,7 +113,7 @@ internal class MessageHandler : ILogSubject
 
         // execute and resolve result data
         this.Trace<string>("execute handler {handlerType}", route.HandlerType.FriendlyName());
-        var resultTask = route.HandleMethod.Invoke(handler, new[] { request, ct })!;
+        var resultTask = route.HandleMethod.Invoke(handler, [request, ct])!;
         await (Task)resultTask;
 
         var dataType = route.ResultProperty.PropertyType;

--- a/base/Mesh/src/Annium.Mesh.Server/Internal/PushCoordinator.cs
+++ b/base/Mesh/src/Annium.Mesh.Server/Internal/PushCoordinator.cs
@@ -78,12 +78,16 @@ internal class PushCoordinator : ILogSubject
 
         var contextType = typeof(PushContext<>).MakeGenericType(route.MessageType);
         this.Trace<string>("create context {contextType}", contextType.FriendlyName());
-        var context = Activator.CreateInstance(contextType, _sender, actionKey, cid, cn, ct, Logger);
+        var context = Activator.CreateInstance(contextType, _sender, actionKey, cid, cn, ct, Logger).NotNull();
 
-        // execute and resolve result data
+        // execute and resolve result data; the context owns a started executor, so dispose it
+        // (draining pending sends) once the handler completes or throws
         this.Trace<string>("execute handler {handlerType}", route.HandlerType.FriendlyName());
-        var resultTask = route.HandleMethod.Invoke(handler, new[] { context, ct })!;
-        await (Task)resultTask;
+        await using ((IAsyncDisposable)context)
+        {
+            var resultTask = route.HandleMethod.Invoke(handler, [context, ct]).NotNull();
+            await (Task)resultTask;
+        }
 
         this.Trace("done");
     }

--- a/base/Mesh/src/Annium.Mesh.Server/ServerConfigurationOptions.cs
+++ b/base/Mesh/src/Annium.Mesh.Server/ServerConfigurationOptions.cs
@@ -97,10 +97,24 @@ public class ServerConfigurationOptions
     /// <param name="implementation">The handler implementation type.</param>
     private void RegisterHandler(ActionKey actionKey, Type implementation)
     {
-        if (RegisterRequestHandler(actionKey, implementation))
+        if (
+            RegisterRequestRoute(
+                actionKey,
+                implementation,
+                typeof(IRequestHandler<,>),
+                nameof(IRequestHandler<,>.HandleAsync)
+            )
+        )
             return;
 
-        if (RegisterRequestResponseHandler(actionKey, implementation))
+        if (
+            RegisterRequestRoute(
+                actionKey,
+                implementation,
+                typeof(IRequestResponseHandler<,,>),
+                nameof(IRequestResponseHandler<,,>.HandleAsync)
+            )
+        )
             return;
 
         if (RegisterPushHandler(actionKey, implementation))
@@ -112,51 +126,19 @@ public class ServerConfigurationOptions
     }
 
     /// <summary>
-    /// Attempts to register a request handler implementation.
+    /// Attempts to register a request or request-response handler implementation into the request routes.
     /// </summary>
     /// <param name="actionKey">The action key identifying the handler.</param>
     /// <param name="implementation">The handler implementation type.</param>
-    /// <returns>True if the handler was successfully registered as a request handler; otherwise, false.</returns>
-    private bool RegisterRequestHandler(ActionKey actionKey, Type implementation)
+    /// <param name="targetType">The handler interface to match (IRequestHandler&lt;,&gt; or IRequestResponseHandler&lt;,,&gt;).</param>
+    /// <param name="handleName">The name of the handle method on the matched interface.</param>
+    /// <returns>True if the handler was successfully registered as a request route; otherwise, false.</returns>
+    private bool RegisterRequestRoute(ActionKey actionKey, Type implementation, Type targetType, string handleName)
     {
-        if (
-            !TryResolveHandler(
-                implementation,
-                typeof(IRequestHandler<,>),
-                nameof(IRequestHandler<,>.HandleAsync),
-                out var info
-            )
-        )
+        if (!TryResolveHandler(implementation, targetType, handleName, out var info))
             return false;
 
-        var resultProperty = info.Handle.ReturnType.GetProperty(nameof(Task<>.Result))!;
-        _routeStore.RequestRoutes.Register(
-            actionKey,
-            new RequestRoute(implementation, info.Handle, info.Args[1], resultProperty)
-        );
-
-        return true;
-    }
-
-    /// <summary>
-    /// Attempts to register a request-response handler implementation.
-    /// </summary>
-    /// <param name="actionKey">The action key identifying the handler.</param>
-    /// <param name="implementation">The handler implementation type.</param>
-    /// <returns>True if the handler was successfully registered as a request-response handler; otherwise, false.</returns>
-    private bool RegisterRequestResponseHandler(ActionKey actionKey, Type implementation)
-    {
-        if (
-            !TryResolveHandler(
-                implementation,
-                typeof(IRequestResponseHandler<,,>),
-                nameof(IRequestResponseHandler<,,>.HandleAsync),
-                out var info
-            )
-        )
-            return false;
-
-        var resultProperty = info.Handle.ReturnType.GetProperty(nameof(Task<>.Result))!;
+        var resultProperty = info.Handle.ReturnType.GetProperty(nameof(Task<>.Result)).NotNull();
         _routeStore.RequestRoutes.Register(
             actionKey,
             new RequestRoute(implementation, info.Handle, info.Args[1], resultProperty)

--- a/base/Mesh/src/Annium.Mesh.Transport.InMemory/Internal/Channel.cs
+++ b/base/Mesh/src/Annium.Mesh.Transport.InMemory/Internal/Channel.cs
@@ -80,6 +80,7 @@ internal class Channel
         {
             if (!_isConnected)
                 return;
+            _isConnected = false;
         }
 
         OnDisconnected(side);

--- a/base/Mesh/tests/Annium.Mesh.Tests/System/Client/Clients/DemoClient.cs
+++ b/base/Mesh/tests/Annium.Mesh.Tests/System/Client/Clients/DemoClient.cs
@@ -52,6 +52,62 @@ public class DemoClient
         CancellationToken ct = default
     ) => _client.FetchAsync(1, Action.Echo, request, defaultValue, ct);
 
+    /// <summary>
+    /// Sends a request whose server handler always returns a non-Ok status with errors.
+    /// </summary>
+    /// <param name="request">The request payload.</param>
+    /// <param name="ct">The cancellation token for the operation.</param>
+    /// <returns>A task with the non-Ok server response.</returns>
+    public Task<IStatusResult<OperationStatus, string?>> FailAsync(
+        EchoRequest request,
+        CancellationToken ct = default
+    ) => _client.FetchAsync<string>(1, Action.Fail, request, ct);
+
+    /// <summary>
+    /// Sends a no-response-data request (exercises the SendAsync path) and returns only the status.
+    /// </summary>
+    /// <param name="request">The request payload.</param>
+    /// <param name="ct">The cancellation token for the operation.</param>
+    /// <returns>A task with the operation status.</returns>
+    public Task<IStatusResult<OperationStatus>> NotifyAsync(EchoRequest request, CancellationToken ct = default) =>
+        _client.SendAsync(1, Action.Notify, request, ct);
+
+    /// <summary>
+    /// Sends a request whose server handler never completes until cancelled, used to exercise caller cancellation.
+    /// </summary>
+    /// <param name="request">The request payload.</param>
+    /// <param name="ct">The cancellation token for the operation.</param>
+    /// <returns>A task with the operation result once cancelled or timed out.</returns>
+    public Task<IStatusResult<OperationStatus, string?>> HangAsync(
+        EchoRequest request,
+        CancellationToken ct = default
+    ) => _client.FetchAsync<string>(1, Action.Hang, request, ct);
+
+    /// <summary>
+    /// Sends a hang request with a default-value fallback, used to exercise the FetchAsync default-value overload
+    /// and its null-response fallback branch.
+    /// </summary>
+    /// <param name="request">The request payload.</param>
+    /// <param name="defaultValue">The value returned when no response arrives.</param>
+    /// <param name="ct">The cancellation token for the operation.</param>
+    /// <returns>A task with the response data or the default value.</returns>
+    public Task<IStatusResult<OperationStatus, string?>> HangAsync(
+        EchoRequest request,
+        string defaultValue,
+        CancellationToken ct = default
+    ) => _client.FetchAsync(1, Action.Hang, request, defaultValue, ct);
+
+    /// <summary>
+    /// Sends a request whose server handler throws, used to verify the connection survives a faulting handler.
+    /// </summary>
+    /// <param name="request">The request payload.</param>
+    /// <param name="ct">The cancellation token for the operation.</param>
+    /// <returns>A task with the operation result (no response arrives).</returns>
+    public Task<IStatusResult<OperationStatus, string?>> ThrowAsync(
+        EchoRequest request,
+        CancellationToken ct = default
+    ) => _client.FetchAsync<string>(1, Action.Throw, request, ct);
+
     // public void Analytics(
     //     AnalyticEvent e
     // ) => _client.Notify(e);

--- a/base/Mesh/tests/Annium.Mesh.Tests/System/Domain/Action.cs
+++ b/base/Mesh/tests/Annium.Mesh.Tests/System/Domain/Action.cs
@@ -14,4 +14,24 @@ public enum Action
     /// Counter action that manages and updates counter values.
     /// </summary>
     Counter,
+
+    /// <summary>
+    /// Action whose handler returns a non-Ok operation status with errors.
+    /// </summary>
+    Fail,
+
+    /// <summary>
+    /// Action whose handler never completes until cancelled, used to exercise caller-side cancellation.
+    /// </summary>
+    Hang,
+
+    /// <summary>
+    /// Action whose handler throws, used to verify a faulting handler does not tear down the connection.
+    /// </summary>
+    Throw,
+
+    /// <summary>
+    /// Action handled by a no-response-data request handler, used to exercise the SendAsync path.
+    /// </summary>
+    Notify,
 }

--- a/base/Mesh/tests/Annium.Mesh.Tests/System/Server/Demo/FailHandler.cs
+++ b/base/Mesh/tests/Annium.Mesh.Tests/System/Server/Demo/FailHandler.cs
@@ -1,0 +1,35 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Annium.Architecture.Base;
+using Annium.Data.Operations;
+using Annium.Mesh.Server;
+using Annium.Mesh.Tests.System.Domain;
+
+namespace Annium.Mesh.Tests.System.Server.Demo;
+
+/// <summary>
+/// Handler that always returns a non-Ok status with an error, used to verify error-status round trips to the client.
+/// </summary>
+internal class FailHandler : IRequestResponseHandler<Action, EchoRequest, string>
+{
+    /// <summary>
+    /// Gets the version of this handler.
+    /// </summary>
+    public static ushort Version => 1;
+
+    /// <summary>
+    /// Gets the action type this handler responds to.
+    /// </summary>
+    public static Action Action => Action.Fail;
+
+    /// <summary>
+    /// Handles the request by returning a NotFound status carrying an error message.
+    /// </summary>
+    /// <param name="request">The incoming request.</param>
+    /// <param name="ct">The cancellation token for the operation.</param>
+    /// <returns>A task with a non-Ok status result.</returns>
+    public Task<IStatusResult<OperationStatus, string>> HandleAsync(EchoRequest request, CancellationToken ct)
+    {
+        return Task.FromResult(Result.Status(OperationStatus.NotFound, string.Empty).Error("not found"));
+    }
+}

--- a/base/Mesh/tests/Annium.Mesh.Tests/System/Server/Demo/HangHandler.cs
+++ b/base/Mesh/tests/Annium.Mesh.Tests/System/Server/Demo/HangHandler.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Annium.Architecture.Base;
+using Annium.Data.Operations;
+using Annium.Mesh.Server;
+using Annium.Mesh.Tests.System.Domain;
+using Action = Annium.Mesh.Tests.System.Domain.Action;
+
+namespace Annium.Mesh.Tests.System.Server.Demo;
+
+/// <summary>
+/// Handler that never produces a response until its cancellation token fires, used to exercise caller-side
+/// cancellation and response-timeout paths on the client.
+/// </summary>
+internal class HangHandler : IRequestResponseHandler<Action, EchoRequest, string>
+{
+    /// <summary>
+    /// Gets the version of this handler.
+    /// </summary>
+    public static ushort Version => 1;
+
+    /// <summary>
+    /// Gets the action type this handler responds to.
+    /// </summary>
+    public static Action Action => Action.Hang;
+
+    /// <summary>
+    /// Handles the request by delaying until cancelled, so the client never receives a timely response.
+    /// </summary>
+    /// <param name="request">The incoming request.</param>
+    /// <param name="ct">The cancellation token (fires on connection teardown).</param>
+    /// <returns>A task that only completes once the token is cancelled.</returns>
+    public async Task<IStatusResult<OperationStatus, string>> HandleAsync(EchoRequest request, CancellationToken ct)
+    {
+        try
+        {
+            await Task.Delay(Timeout.Infinite, ct);
+        }
+        catch (OperationCanceledException)
+        {
+            // connection teardown — expected; fall through and return.
+        }
+
+        return Result.Status(OperationStatus.Ok, request.Message);
+    }
+}

--- a/base/Mesh/tests/Annium.Mesh.Tests/System/Server/Demo/NotifyHandler.cs
+++ b/base/Mesh/tests/Annium.Mesh.Tests/System/Server/Demo/NotifyHandler.cs
@@ -1,0 +1,36 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Annium.Architecture.Base;
+using Annium.Data.Operations;
+using Annium.Mesh.Server;
+using Annium.Mesh.Tests.System.Domain;
+
+namespace Annium.Mesh.Tests.System.Server.Demo;
+
+/// <summary>
+/// No-response-data request handler (IRequestHandler), used to exercise the client SendAsync path that
+/// returns only a status result.
+/// </summary>
+internal class NotifyHandler : IRequestHandler<Action, EchoRequest>
+{
+    /// <summary>
+    /// Gets the version of this handler.
+    /// </summary>
+    public static ushort Version => 1;
+
+    /// <summary>
+    /// Gets the action type this handler responds to.
+    /// </summary>
+    public static Action Action => Action.Notify;
+
+    /// <summary>
+    /// Handles the request and returns an Ok status with no response data.
+    /// </summary>
+    /// <param name="request">The incoming request.</param>
+    /// <param name="ct">The cancellation token for the operation.</param>
+    /// <returns>A task with an Ok status result.</returns>
+    public Task<IStatusResult<OperationStatus>> HandleAsync(EchoRequest request, CancellationToken ct)
+    {
+        return Task.FromResult(Result.Status(OperationStatus.Ok));
+    }
+}

--- a/base/Mesh/tests/Annium.Mesh.Tests/System/Server/Demo/ThrowHandler.cs
+++ b/base/Mesh/tests/Annium.Mesh.Tests/System/Server/Demo/ThrowHandler.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Annium.Architecture.Base;
+using Annium.Data.Operations;
+using Annium.Mesh.Server;
+using Annium.Mesh.Tests.System.Domain;
+using Action = Annium.Mesh.Tests.System.Domain.Action;
+
+namespace Annium.Mesh.Tests.System.Server.Demo;
+
+/// <summary>
+/// Handler that throws synchronously, used to verify a faulting request handler does not tear down the
+/// connection for other in-flight or subsequent requests.
+/// </summary>
+internal class ThrowHandler : IRequestResponseHandler<Action, EchoRequest, string>
+{
+    /// <summary>
+    /// Gets the version of this handler.
+    /// </summary>
+    public static ushort Version => 1;
+
+    /// <summary>
+    /// Gets the action type this handler responds to.
+    /// </summary>
+    public static Action Action => Action.Throw;
+
+    /// <summary>
+    /// Handles the request by throwing, simulating a misbehaving handler.
+    /// </summary>
+    /// <param name="request">The incoming request.</param>
+    /// <param name="ct">The cancellation token for the operation.</param>
+    /// <returns>Never returns normally; always throws.</returns>
+    public Task<IStatusResult<OperationStatus, string>> HandleAsync(EchoRequest request, CancellationToken ct)
+    {
+        throw new InvalidOperationException("handler boom");
+    }
+}

--- a/base/Mesh/tests/Annium.Mesh.Tests/Variants/Base/RequestTestsBase.cs
+++ b/base/Mesh/tests/Annium.Mesh.Tests/Variants/Base/RequestTestsBase.cs
@@ -1,11 +1,14 @@
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Annium.Architecture.Base;
 using Annium.Data.Operations;
 using Annium.Logging;
 using Annium.Mesh.Tests.System.Domain;
+using Annium.Mesh.Transport.Abstractions;
 using Annium.Testing;
 using Xunit;
 
@@ -81,6 +84,182 @@ public abstract class RequestTestsBase<TBehavior> : TestBase<TBehavior>
         set.Has(range.Length);
         foreach (var x in range)
             set.Contains(x).IsTrue();
+
+        this.Trace("done");
+    }
+
+    /// <summary>
+    /// Verifies a handler returning a non-Ok status result surfaces that status and its errors to the caller.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    protected async Task Fail_ReturnsNonOkStatus_Base()
+    {
+        this.Trace("start");
+
+        // arrange
+        await using var client = await GetClient();
+
+        // act
+        var response = await client.Demo.FailAsync(new EchoRequest("ignored"));
+
+        // assert
+        response.Status.Is(OperationStatus.NotFound);
+        response.HasErrors.IsTrue();
+
+        this.Trace("done");
+    }
+
+    /// <summary>
+    /// Verifies cancelling the caller token before a response arrives yields an Aborted status rather than hanging.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    protected async Task Cancel_ReturnsAborted_Base()
+    {
+        this.Trace("start");
+
+        // arrange
+        await using var client = await GetClient();
+        using var cts = new CancellationTokenSource();
+
+        // act
+        var task = client.Demo.HangAsync(new EchoRequest("ignored"), cts.Token);
+        await cts.CancelAsync();
+        var response = await task;
+
+        // assert
+        response.Status.Is(OperationStatus.Aborted);
+
+        this.Trace("done");
+    }
+
+    /// <summary>
+    /// Verifies a request whose handler throws does not fault the connection: a subsequent request still succeeds.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    protected async Task Throw_KeepsConnectionAlive_Base()
+    {
+        this.Trace("start");
+
+        // arrange
+        await using var client = await GetClient();
+
+        // act — the throwing handler never responds; bound the wait so the test stays fast
+        using (var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(500)))
+        {
+            var failed = await client.Demo.ThrowAsync(new EchoRequest("boom"), cts.Token);
+            failed.Status.IsNotEqual(OperationStatus.Ok);
+        }
+
+        // assert — the same connection still serves a normal request
+        var response = await client.Demo.EchoAsync(new EchoRequest("alive"));
+        response.Status.Is(OperationStatus.Ok);
+        response.Data.Is("alive");
+
+        this.Trace("done");
+    }
+
+    /// <summary>
+    /// Verifies disposing an already-disposed client is idempotent and does not throw.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    protected async Task Dispose_Twice_DoesNotThrow_Base()
+    {
+        this.Trace("start");
+
+        // arrange
+        var client = await GetClient();
+
+        // act + assert — a second dispose must complete without throwing
+        await client.DisposeAsync();
+        await client.DisposeAsync();
+
+        this.Trace("done");
+    }
+
+    /// <summary>
+    /// Verifies an explicit client disconnect raises OnDisconnected with a local-close status.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    protected async Task Disconnect_FiresOnDisconnected_Base()
+    {
+        this.Trace("start");
+
+        // arrange
+        await using var client = await GetClient();
+        var tcs = new TaskCompletionSource<ConnectionCloseStatus>(TaskCreationOptions.RunContinuationsAsynchronously);
+        client.OnDisconnected += status => tcs.TrySetResult(status);
+
+        // act
+        client.Disconnect();
+        var status = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // assert
+        status.Is(ConnectionCloseStatus.ClosedLocal);
+
+        this.Trace("done");
+    }
+
+    /// <summary>
+    /// Verifies a no-response-data request (SendAsync path via an IRequestHandler) returns an Ok status.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    protected async Task Send_ReturnsOkStatus_Base()
+    {
+        this.Trace("start");
+
+        // arrange
+        await using var client = await GetClient();
+
+        // act
+        var response = await client.Demo.NotifyAsync(new EchoRequest("notify"));
+
+        // assert
+        response.Status.Is(OperationStatus.Ok);
+
+        this.Trace("done");
+    }
+
+    /// <summary>
+    /// Verifies the FetchAsync default-value overload returns the actual response data on success (not the default).
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    protected async Task FetchWithDefault_Success_ReturnsData_Base()
+    {
+        this.Trace("start");
+
+        // arrange
+        await using var client = await GetClient();
+
+        // act
+        var response = await client.Demo.EchoAsync(new EchoRequest("actual"), "fallback");
+
+        // assert
+        response.Status.Is(OperationStatus.Ok);
+        response.Data.Is("actual");
+
+        this.Trace("done");
+    }
+
+    /// <summary>
+    /// Verifies the FetchAsync default-value overload returns the default when no response arrives (null-response fallback).
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    protected async Task FetchWithDefault_Cancelled_ReturnsDefault_Base()
+    {
+        this.Trace("start");
+
+        // arrange
+        await using var client = await GetClient();
+        using var cts = new CancellationTokenSource();
+
+        // act — cancel before any response; the fallback default must be returned
+        var task = client.Demo.HangAsync(new EchoRequest("ignored"), "fallback", cts.Token);
+        await cts.CancelAsync();
+        var response = await task;
+
+        // assert
+        response.Status.Is(OperationStatus.Aborted);
+        response.Data.Is("fallback");
 
         this.Trace("done");
     }

--- a/base/Mesh/tests/Annium.Mesh.Tests/Variants/InMemory/EventTests.cs
+++ b/base/Mesh/tests/Annium.Mesh.Tests/Variants/InMemory/EventTests.cs
@@ -21,7 +21,7 @@ public class EventTests : EventTestsBase<Behavior>
     /// Tests analytics event handling using in-memory transport.
     /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
-    [Fact]
+    [Fact(Skip = "broadcast and event feature not wired (dark WIP): handlers commented out, body is a no-op")]
     public async Task Analytics()
     {
         this.Trace("start");

--- a/base/Mesh/tests/Annium.Mesh.Tests/Variants/InMemory/RequestTests.cs
+++ b/base/Mesh/tests/Annium.Mesh.Tests/Variants/InMemory/RequestTests.cs
@@ -1,6 +1,9 @@
+using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Annium.Logging;
 using Annium.Mesh.Tests.Variants.Base;
+using Annium.Testing;
 using Xunit;
 
 namespace Annium.Mesh.Tests.Variants.InMemory;
@@ -27,6 +30,149 @@ public class RequestTests : RequestTestsBase<Behavior>
         this.Trace("start");
 
         await Echo_Base();
+
+        this.Trace("done");
+    }
+
+    /// <summary>
+    /// Tests that a non-Ok handler status surfaces to the caller.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task Fail()
+    {
+        this.Trace("start");
+
+        await Fail_ReturnsNonOkStatus_Base();
+
+        this.Trace("done");
+    }
+
+    /// <summary>
+    /// Tests that caller-side cancellation yields an Aborted status.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task Cancel()
+    {
+        this.Trace("start");
+
+        await Cancel_ReturnsAborted_Base();
+
+        this.Trace("done");
+    }
+
+    /// <summary>
+    /// Tests that a throwing handler does not fault the connection.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task Throw_KeepsConnectionAlive()
+    {
+        this.Trace("start");
+
+        await Throw_KeepsConnectionAlive_Base();
+
+        this.Trace("done");
+    }
+
+    /// <summary>
+    /// Tests that double-dispose of the client is idempotent.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task Dispose_Twice_DoesNotThrow()
+    {
+        this.Trace("start");
+
+        await Dispose_Twice_DoesNotThrow_Base();
+
+        this.Trace("done");
+    }
+
+    /// <summary>
+    /// Tests that an explicit disconnect raises OnDisconnected with a local-close status.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task Disconnect_FiresOnDisconnected()
+    {
+        this.Trace("start");
+
+        await Disconnect_FiresOnDisconnected_Base();
+
+        this.Trace("done");
+    }
+
+    /// <summary>
+    /// Verifies the InMemory channel is disconnected idempotently: an explicit disconnect followed by
+    /// disposal (a second disconnect) raises OnDisconnected exactly once, not twice.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task Disconnect_FiresOnDisconnectedOnce()
+    {
+        this.Trace("start");
+
+        // arrange
+        await using var client = await GetClient();
+        var count = 0;
+        var firstFired = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        client.OnDisconnected += _ =>
+        {
+            Interlocked.Increment(ref count);
+            firstFired.TrySetResult();
+        };
+
+        // act — explicit disconnect, then dispose (which disconnects again)
+        client.Disconnect();
+        await firstFired.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        await client.DisposeAsync();
+
+        // assert — the second disconnect must be a no-op
+        Volatile.Read(ref count).Is(1);
+
+        this.Trace("done");
+    }
+
+    /// <summary>
+    /// Tests that a no-response-data request (SendAsync) returns Ok.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task Send()
+    {
+        this.Trace("start");
+
+        await Send_ReturnsOkStatus_Base();
+
+        this.Trace("done");
+    }
+
+    /// <summary>
+    /// Tests that the FetchAsync default-value overload returns actual data on success.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task FetchWithDefault_Success()
+    {
+        this.Trace("start");
+
+        await FetchWithDefault_Success_ReturnsData_Base();
+
+        this.Trace("done");
+    }
+
+    /// <summary>
+    /// Tests that the FetchAsync default-value overload returns the default on a null response.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task FetchWithDefault_Cancelled()
+    {
+        this.Trace("start");
+
+        await FetchWithDefault_Cancelled_ReturnsDefault_Base();
 
         this.Trace("done");
     }

--- a/base/Mesh/tests/Annium.Mesh.Tests/Variants/InMemory/SubscriptionPerfTests.cs
+++ b/base/Mesh/tests/Annium.Mesh.Tests/Variants/InMemory/SubscriptionPerfTests.cs
@@ -24,7 +24,7 @@ public class SubscriptionPerfTests : SubscriptionTestsBase<Behavior>
     /// </summary>
     /// <param name="index">The test iteration index.</param>
     /// <returns>A task that represents the asynchronous test operation.</returns>
-    [Theory]
+    [Theory(Skip = "subscription feature not wired (dark WIP): handlers commented out, body is a no-op")]
     [MemberData(nameof(GetPerfRange))]
     public async Task Subscription(int index)
     {

--- a/base/Mesh/tests/Annium.Mesh.Tests/Variants/InMemory/SubscriptionTests.cs
+++ b/base/Mesh/tests/Annium.Mesh.Tests/Variants/InMemory/SubscriptionTests.cs
@@ -21,7 +21,7 @@ public class SubscriptionTests : SubscriptionTestsBase<Behavior>
     /// Tests subscription messaging.
     /// </summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
-    [Fact]
+    [Fact(Skip = "subscription feature not wired (dark WIP): handlers commented out, body is a no-op")]
     public async Task Subscription()
     {
         this.Trace("start");

--- a/base/Mesh/tests/Annium.Mesh.Tests/Variants/Sockets/EventTests.cs
+++ b/base/Mesh/tests/Annium.Mesh.Tests/Variants/Sockets/EventTests.cs
@@ -21,7 +21,7 @@ public class EventTests : EventTestsBase<Behavior>
     /// Tests analytics event messaging.
     /// </summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
-    [Fact]
+    [Fact(Skip = "broadcast and event feature not wired (dark WIP): handlers commented out, body is a no-op")]
     public async Task Analytics()
     {
         this.Trace("start");

--- a/base/Mesh/tests/Annium.Mesh.Tests/Variants/Sockets/RequestTests.cs
+++ b/base/Mesh/tests/Annium.Mesh.Tests/Variants/Sockets/RequestTests.cs
@@ -30,4 +30,116 @@ public class RequestTests : RequestTestsBase<Behavior>
 
         this.Trace("done");
     }
+
+    /// <summary>
+    /// Tests that a non-Ok handler status surfaces to the caller.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task Fail()
+    {
+        this.Trace("start");
+
+        await Fail_ReturnsNonOkStatus_Base();
+
+        this.Trace("done");
+    }
+
+    /// <summary>
+    /// Tests that caller-side cancellation yields an Aborted status.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task Cancel()
+    {
+        this.Trace("start");
+
+        await Cancel_ReturnsAborted_Base();
+
+        this.Trace("done");
+    }
+
+    /// <summary>
+    /// Tests that a throwing handler does not fault the connection.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task Throw_KeepsConnectionAlive()
+    {
+        this.Trace("start");
+
+        await Throw_KeepsConnectionAlive_Base();
+
+        this.Trace("done");
+    }
+
+    /// <summary>
+    /// Tests that double-dispose of the client is idempotent.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task Dispose_Twice_DoesNotThrow()
+    {
+        this.Trace("start");
+
+        await Dispose_Twice_DoesNotThrow_Base();
+
+        this.Trace("done");
+    }
+
+    /// <summary>
+    /// Tests that an explicit disconnect raises OnDisconnected with a local-close status.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task Disconnect_FiresOnDisconnected()
+    {
+        this.Trace("start");
+
+        await Disconnect_FiresOnDisconnected_Base();
+
+        this.Trace("done");
+    }
+
+    /// <summary>
+    /// Tests that a no-response-data request (SendAsync) returns Ok.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task Send()
+    {
+        this.Trace("start");
+
+        await Send_ReturnsOkStatus_Base();
+
+        this.Trace("done");
+    }
+
+    /// <summary>
+    /// Tests that the FetchAsync default-value overload returns actual data on success.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task FetchWithDefault_Success()
+    {
+        this.Trace("start");
+
+        await FetchWithDefault_Success_ReturnsData_Base();
+
+        this.Trace("done");
+    }
+
+    /// <summary>
+    /// Tests that the FetchAsync default-value overload returns the default on a null response.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task FetchWithDefault_Cancelled()
+    {
+        this.Trace("start");
+
+        await FetchWithDefault_Cancelled_ReturnsDefault_Base();
+
+        this.Trace("done");
+    }
 }

--- a/base/Mesh/tests/Annium.Mesh.Tests/Variants/Sockets/SubscriptionPerfTests.cs
+++ b/base/Mesh/tests/Annium.Mesh.Tests/Variants/Sockets/SubscriptionPerfTests.cs
@@ -24,7 +24,7 @@ public class SubscriptionPerfTests : SubscriptionTestsBase<Behavior>
     /// </summary>
     /// <param name="index">The test iteration index.</param>
     /// <returns>A task that represents the asynchronous test operation.</returns>
-    [Theory]
+    [Theory(Skip = "subscription feature not wired (dark WIP): handlers commented out, body is a no-op")]
     [MemberData(nameof(GetPerfRange))]
     public async Task Subscription(int index)
     {

--- a/base/Mesh/tests/Annium.Mesh.Tests/Variants/Sockets/SubscriptionTests.cs
+++ b/base/Mesh/tests/Annium.Mesh.Tests/Variants/Sockets/SubscriptionTests.cs
@@ -21,7 +21,7 @@ public class SubscriptionTests : SubscriptionTestsBase<Behavior>
     /// Tests subscription messaging.
     /// </summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
-    [Fact]
+    [Fact(Skip = "subscription feature not wired (dark WIP): handlers commented out, body is a no-op")]
     public async Task Subscription()
     {
         this.Trace("start");

--- a/base/Mesh/tests/Annium.Mesh.Tests/Variants/WebSockets/EventTests.cs
+++ b/base/Mesh/tests/Annium.Mesh.Tests/Variants/WebSockets/EventTests.cs
@@ -21,7 +21,7 @@ public class EventTests : EventTestsBase<Behavior>
     /// Tests analytics event messaging.
     /// </summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
-    [Fact]
+    [Fact(Skip = "broadcast and event feature not wired (dark WIP): handlers commented out, body is a no-op")]
     public async Task Analytics()
     {
         this.Trace("start");

--- a/base/Mesh/tests/Annium.Mesh.Tests/Variants/WebSockets/RequestTests.cs
+++ b/base/Mesh/tests/Annium.Mesh.Tests/Variants/WebSockets/RequestTests.cs
@@ -30,4 +30,116 @@ public class RequestTests : RequestTestsBase<Behavior>
 
         this.Trace("done");
     }
+
+    /// <summary>
+    /// Tests that a non-Ok handler status surfaces to the caller.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task Fail()
+    {
+        this.Trace("start");
+
+        await Fail_ReturnsNonOkStatus_Base();
+
+        this.Trace("done");
+    }
+
+    /// <summary>
+    /// Tests that caller-side cancellation yields an Aborted status.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task Cancel()
+    {
+        this.Trace("start");
+
+        await Cancel_ReturnsAborted_Base();
+
+        this.Trace("done");
+    }
+
+    /// <summary>
+    /// Tests that a throwing handler does not fault the connection.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task Throw_KeepsConnectionAlive()
+    {
+        this.Trace("start");
+
+        await Throw_KeepsConnectionAlive_Base();
+
+        this.Trace("done");
+    }
+
+    /// <summary>
+    /// Tests that double-dispose of the client is idempotent.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task Dispose_Twice_DoesNotThrow()
+    {
+        this.Trace("start");
+
+        await Dispose_Twice_DoesNotThrow_Base();
+
+        this.Trace("done");
+    }
+
+    /// <summary>
+    /// Tests that an explicit disconnect raises OnDisconnected with a local-close status.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task Disconnect_FiresOnDisconnected()
+    {
+        this.Trace("start");
+
+        await Disconnect_FiresOnDisconnected_Base();
+
+        this.Trace("done");
+    }
+
+    /// <summary>
+    /// Tests that a no-response-data request (SendAsync) returns Ok.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task Send()
+    {
+        this.Trace("start");
+
+        await Send_ReturnsOkStatus_Base();
+
+        this.Trace("done");
+    }
+
+    /// <summary>
+    /// Tests that the FetchAsync default-value overload returns actual data on success.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task FetchWithDefault_Success()
+    {
+        this.Trace("start");
+
+        await FetchWithDefault_Success_ReturnsData_Base();
+
+        this.Trace("done");
+    }
+
+    /// <summary>
+    /// Tests that the FetchAsync default-value overload returns the default on a null response.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task FetchWithDefault_Cancelled()
+    {
+        this.Trace("start");
+
+        await FetchWithDefault_Cancelled_ReturnsDefault_Base();
+
+        this.Trace("done");
+    }
 }

--- a/base/Mesh/tests/Annium.Mesh.Tests/Variants/WebSockets/SubscriptionPerfTests.cs
+++ b/base/Mesh/tests/Annium.Mesh.Tests/Variants/WebSockets/SubscriptionPerfTests.cs
@@ -24,7 +24,7 @@ public class SubscriptionPerfTests : SubscriptionTestsBase<Behavior>
     /// </summary>
     /// <param name="index">The test iteration index.</param>
     /// <returns>A task that represents the asynchronous test operation.</returns>
-    [Theory]
+    [Theory(Skip = "subscription feature not wired (dark WIP): handlers commented out, body is a no-op")]
     [MemberData(nameof(GetPerfRange))]
     public async Task Subscription(int index)
     {

--- a/base/Mesh/tests/Annium.Mesh.Tests/Variants/WebSockets/SubscriptionTests.cs
+++ b/base/Mesh/tests/Annium.Mesh.Tests/Variants/WebSockets/SubscriptionTests.cs
@@ -21,7 +21,7 @@ public class SubscriptionTests : SubscriptionTestsBase<Behavior>
     /// Tests subscription messaging.
     /// </summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
-    [Fact]
+    [Fact(Skip = "subscription feature not wired (dark WIP): handlers commented out, body is a no-op")]
     public async Task Subscription()
     {
         this.Trace("start");


### PR DESCRIPTION
     PushCoordinator created a PushContext (IAsyncDisposable owning a started
     executor) per push route and never disposed it. InMemory Channel.Disconnect
     never cleared _isConnected, so a second disconnect re-fired OnDisconnected
     and post-disconnect sends still reported Ok. ClientBase.FetchRawAsync
     discarded its ct.Register registration, accumulating callbacks on a reused
     caller token.

     Also: Server.Web Handler is internal with constructor injection (mirrors the
     Sockets sibling); the two identical request registrars collapse into
     RegisterRequestRoute; bare ! replaced with NotNull(). Adds 18 request and
     lifecycle facts across all three transports plus a red-green repro for the
     disconnect fix, and marks the 9 hollow subscription/analytics facts
     [Fact(Skip)] — those features are commented-out WIP.