### PR TITLE
fix(storage): restore S3 test discovery and fix the bugs it exposed

### DIFF
--- a/Annium.Backend.sln
+++ b/Annium.Backend.sln
@@ -189,6 +189,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Annium.MessageBus.RabbitMq.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Annium.MessageBus.Nats.Load", "base\MessageBus\tests\Annium.MessageBus.Nats.Load\Annium.MessageBus.Nats.Load.csproj", "{99143831-DD85-40D9-ADA4-2C4CD2CF5994}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Annium.Storage.Abstractions.Tests", "base\Storage\tests\Annium.Storage.Abstractions.Tests\Annium.Storage.Abstractions.Tests.csproj", "{FC603ED6-6DA7-4F3F-885C-4AE709AC9B6A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -943,6 +945,18 @@ Global
 		{99143831-DD85-40D9-ADA4-2C4CD2CF5994}.Release|x64.Build.0 = Release|Any CPU
 		{99143831-DD85-40D9-ADA4-2C4CD2CF5994}.Release|x86.ActiveCfg = Release|Any CPU
 		{99143831-DD85-40D9-ADA4-2C4CD2CF5994}.Release|x86.Build.0 = Release|Any CPU
+		{FC603ED6-6DA7-4F3F-885C-4AE709AC9B6A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FC603ED6-6DA7-4F3F-885C-4AE709AC9B6A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FC603ED6-6DA7-4F3F-885C-4AE709AC9B6A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FC603ED6-6DA7-4F3F-885C-4AE709AC9B6A}.Debug|x64.Build.0 = Debug|Any CPU
+		{FC603ED6-6DA7-4F3F-885C-4AE709AC9B6A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FC603ED6-6DA7-4F3F-885C-4AE709AC9B6A}.Debug|x86.Build.0 = Debug|Any CPU
+		{FC603ED6-6DA7-4F3F-885C-4AE709AC9B6A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FC603ED6-6DA7-4F3F-885C-4AE709AC9B6A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FC603ED6-6DA7-4F3F-885C-4AE709AC9B6A}.Release|x64.ActiveCfg = Release|Any CPU
+		{FC603ED6-6DA7-4F3F-885C-4AE709AC9B6A}.Release|x64.Build.0 = Release|Any CPU
+		{FC603ED6-6DA7-4F3F-885C-4AE709AC9B6A}.Release|x86.ActiveCfg = Release|Any CPU
+		{FC603ED6-6DA7-4F3F-885C-4AE709AC9B6A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1039,5 +1053,6 @@ Global
 		{26D8F386-BFCC-4B9D-9D4F-42DA7196B72A} = {93295A56-520B-BCE0-CD6E-B21CE57A429B}
 		{4AA425A9-3679-4F94-9E23-B38CFCDC4D4C} = {93295A56-520B-BCE0-CD6E-B21CE57A429B}
 		{99143831-DD85-40D9-ADA4-2C4CD2CF5994} = {93295A56-520B-BCE0-CD6E-B21CE57A429B}
+		{FC603ED6-6DA7-4F3F-885C-4AE709AC9B6A} = {3D6022F9-44DC-89AC-7A81-1480EB1EC0F6}
 	EndGlobalSection
 EndGlobal

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -44,6 +44,7 @@
     <PackageVersion Include="StackExchange.Redis" Version="2.13.17" />
     <PackageVersion Include="System.Reactive" Version="6.1.0" />
     <PackageVersion Include="Testcontainers.Kafka" Version="4.12.0" />
+    <PackageVersion Include="Testcontainers.Minio" Version="4.12.0" />
     <PackageVersion Include="Testcontainers.Nats" Version="4.12.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.12.0" />
     <PackageVersion Include="Testcontainers.RabbitMq" Version="4.12.0" />

--- a/base/Storage/src/Annium.Storage.Abstractions/StorageHelper.cs
+++ b/base/Storage/src/Annium.Storage.Abstractions/StorageHelper.cs
@@ -9,10 +9,12 @@ namespace Annium.Storage.Abstractions;
 public static class StorageHelper
 {
     /// <summary>
-    /// Regular expression for validating path component names
+    /// Regular expression for validating path component names. Spelled A-Za-z rather than A-z, which
+    /// would span the punctuation between Z and a — notably the backslash a part must never contain,
+    /// since it separates directories on Windows
     /// </summary>
     private static readonly Regex _nameRe = new(
-        @"^(?:[A-z0-9]+|\.?[A-z0-9]+[A-z0-9-_.]*[A-z0-9]+)$",
+        @"^(?:[A-Za-z0-9_]+|\.?[A-Za-z0-9_]+[A-Za-z0-9-_.]*[A-Za-z0-9_]+)$",
         RegexOptions.Compiled | RegexOptions.Singleline
     );
 

--- a/base/Storage/src/Annium.Storage.FileSystem/Internal/Storage.cs
+++ b/base/Storage/src/Annium.Storage.FileSystem/Internal/Storage.cs
@@ -43,7 +43,20 @@ internal class Storage : IStorage, ILogSubject
     /// <returns>Array of file paths matching the prefix</returns>
     public Task<string[]> ListAsync(string prefix = "")
     {
+        // besides rejecting malformed prefixes, this keeps an absolute prefix from escaping the
+        // root: Path.Combine discards the root when the prefix it is combined with is absolute
+        VerifyPrefix(prefix);
+
         var root = prefix == "" ? _directory : Path.Combine(_directory, prefix);
+
+        // a prefix naming a file matches that file, as it does in the other storages, where nothing
+        // distinguishes an item from the directory-like prefix leading to it
+        if (File.Exists(root))
+            return Task.FromResult<string[]>([prefix]);
+
+        if (!Directory.Exists(root))
+            return Task.FromResult<string[]>([]);
+
         var files = Directory
             .GetFiles(root, "*", SearchOption.AllDirectories)
             .Select(e => Path.GetRelativePath(_directory, e))

--- a/base/Storage/src/Annium.Storage.InMemory/Internal/Storage.cs
+++ b/base/Storage/src/Annium.Storage.InMemory/Internal/Storage.cs
@@ -52,7 +52,7 @@ internal class Storage(ILogger logger) : IStorage, ILogSubject
         VerifyPath(path);
 
         using var ms = new MemoryStream();
-        ms.Position = 0;
+        source.Position = 0;
         await source.CopyToAsync(ms);
 
         _storage[path] = ms.ToArray();
@@ -82,6 +82,8 @@ internal class Storage(ILogger logger) : IStorage, ILogSubject
     {
         VerifyPath(path);
 
-        return Task.FromResult(_storage.Remove(path, out _));
+        // TryRemove, not the IDictionary Remove extension, which reads then removes non-atomically
+        // and so reports success to every racing caller
+        return Task.FromResult(_storage.TryRemove(path, out _));
     }
 }

--- a/base/Storage/src/Annium.Storage.S3/Annium.Storage.S3.csproj
+++ b/base/Storage/src/Annium.Storage.S3/Annium.Storage.S3.csproj
@@ -11,4 +11,7 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" />
   </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="Annium.Storage.S3.Tests" />
+  </ItemGroup>
 </Project>

--- a/base/Storage/src/Annium.Storage.S3/Configuration.cs
+++ b/base/Storage/src/Annium.Storage.S3/Configuration.cs
@@ -34,4 +34,16 @@ public record Configuration
     /// The directory prefix within the bucket where files will be stored
     /// </summary>
     public string Directory { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Whether to address the bucket by path (<c>{server}/{bucket}/{key}</c>) rather than by virtual host
+    /// (<c>{bucket}.{server}/{key}</c>). Required by most S3-compatible servers (MinIO, Ceph) and by buckets whose name contains dots
+    /// </summary>
+    public bool ForcePathStyle { get; init; }
+
+    /// <summary>
+    /// How many keys a single list request asks for. Listing pages through the whole result regardless,
+    /// so this trades round trips against response size. Defaults to 1000, the maximum S3 serves per page
+    /// </summary>
+    public int PageSize { get; init; } = 1000;
 }

--- a/base/Storage/src/Annium.Storage.S3/Internal/Storage.cs
+++ b/base/Storage/src/Annium.Storage.S3/Internal/Storage.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using Amazon;
 using Amazon.Runtime;
@@ -56,22 +57,35 @@ internal class Storage : IStorage, ILogSubject
     {
         VerifyPrefix(prefix);
 
-        var listRequest = new ListObjectsRequest
+        var listRequest = new ListObjectsV2Request
         {
             BucketName = _configuration.Bucket,
-            MaxKeys = 100,
+            MaxKeys = _configuration.PageSize,
             Prefix = _directory == "" ? prefix : $"{_directory}/{prefix}",
         };
 
         using var s3 = GetClient();
 
-        var objects = (await s3.ListObjectsAsync(listRequest)).S3Objects;
+        var objects = new List<S3Object>();
+        ListObjectsV2Response response;
+        do
+        {
+            response = await s3.ListObjectsV2Async(listRequest);
+            // an empty listing yields a null collection, not an empty one
+            objects.AddRange(response.S3Objects ?? []);
+            // a listing is returned one page at a time; keep asking until the last page
+            listRequest.ContinuationToken = response.NextContinuationToken;
+        } while (response.IsTruncated ?? false);
 
-        if (_directory == "")
-            return objects.Select(x => x.Key).ToArray();
+        var shift = _directory == "" ? 0 : _directory.Length + 1;
+        var keys = objects.Select(x => x.Key[shift..]);
 
-        var shift = _directory.Length + 1;
-        return objects.Select(x => x.Key[shift..]).ToArray();
+        // the request prefix matches raw characters, so narrow it to whole path segments and keep
+        // the prefix meaning the same here as in the other storages
+        if (prefix != "")
+            keys = keys.Where(x => x == prefix || x.StartsWith($"{prefix}/"));
+
+        return keys.ToArray();
     }
 
     /// <summary>
@@ -119,7 +133,7 @@ internal class Storage : IStorage, ILogSubject
 
             return ms;
         }
-        catch (AmazonS3Exception)
+        catch (AmazonS3Exception e) when (IsNotFound(e))
         {
             throw new KeyNotFoundException($"{path} not found in storage");
         }
@@ -136,13 +150,14 @@ internal class Storage : IStorage, ILogSubject
 
         using var s3 = GetClient();
 
-        var getRequest = new GetObjectRequest { BucketName = _configuration.Bucket, Key = GetKey(path) };
+        // a HEAD answers whether the object is there without fetching its contents
+        var headRequest = new GetObjectMetadataRequest { BucketName = _configuration.Bucket, Key = GetKey(path) };
 
         try
         {
-            await s3.GetObjectAsync(getRequest);
+            await s3.GetObjectMetadataAsync(headRequest);
         }
-        catch (AmazonS3Exception)
+        catch (AmazonS3Exception e) when (IsNotFound(e))
         {
             return false;
         }
@@ -151,6 +166,17 @@ internal class Storage : IStorage, ILogSubject
         await s3.DeleteObjectAsync(deleteRequest);
 
         return true;
+    }
+
+    /// <summary>
+    /// Determines whether a failure means the object is absent, as opposed to the request itself failing
+    /// (denied, throttled, server error) — which must surface rather than read as a missing object
+    /// </summary>
+    /// <param name="e">The exception raised by the S3 request</param>
+    /// <returns>True if the object is absent</returns>
+    private static bool IsNotFound(AmazonS3Exception e)
+    {
+        return e.StatusCode == HttpStatusCode.NotFound || e.ErrorCode is "NoSuchKey" or "NoSuchBucket" or "NotFound";
     }
 
     /// <summary>
@@ -172,9 +198,14 @@ internal class Storage : IStorage, ILogSubject
         {
             RegionEndpoint = RegionEndpoint.GetBySystemName(_configuration.Region),
             RetryMode = RequestRetryMode.Adaptive,
+            ForcePathStyle = _configuration.ForcePathStyle,
         };
         if (!string.IsNullOrWhiteSpace(_configuration.Server))
+        {
+            // ServiceURL and RegionEndpoint are mutually exclusive; keep Region as the signing region
             s3Cfg.ServiceURL = _configuration.Server;
+            s3Cfg.AuthenticationRegion = _configuration.Region;
+        }
 
         var credentials = new BasicAWSCredentials(_configuration.AccessKey, _configuration.AccessSecret);
 

--- a/base/Storage/src/Annium.Storage.S3/Internal/Storage.cs
+++ b/base/Storage/src/Annium.Storage.S3/Internal/Storage.cs
@@ -185,31 +185,44 @@ internal class Storage : IStorage, ILogSubject
     /// <returns>A configured AmazonS3Client instance</returns>
     private AmazonS3Client GetClient()
     {
-        if (string.IsNullOrWhiteSpace(_configuration.AccessKey))
-            throw new ArgumentException("Access key is required");
-
-        if (string.IsNullOrWhiteSpace(_configuration.AccessSecret))
-            throw new ArgumentException("Access secret is required");
-
-        if (string.IsNullOrWhiteSpace(_configuration.Bucket))
-            throw new ArgumentException("Bucket name is required");
-
-        var s3Cfg = new AmazonS3Config
-        {
-            RegionEndpoint = RegionEndpoint.GetBySystemName(_configuration.Region),
-            RetryMode = RequestRetryMode.Adaptive,
-            ForcePathStyle = _configuration.ForcePathStyle,
-        };
-        if (!string.IsNullOrWhiteSpace(_configuration.Server))
-        {
-            // ServiceURL and RegionEndpoint are mutually exclusive; keep Region as the signing region
-            s3Cfg.ServiceURL = _configuration.Server;
-            s3Cfg.AuthenticationRegion = _configuration.Region;
-        }
+        var s3Cfg = GetClientConfig(_configuration);
 
         var credentials = new BasicAWSCredentials(_configuration.AccessKey, _configuration.AccessSecret);
 
         return new AmazonS3Client(credentials, s3Cfg);
+    }
+
+    /// <summary>
+    /// Builds the client configuration from the storage configuration, without contacting the server —
+    /// so the endpoint choice is decidable on its own, including the AWS path no test server exercises
+    /// </summary>
+    /// <param name="configuration">The configuration containing S3 connection details</param>
+    /// <returns>A configured AmazonS3Config instance</returns>
+    internal static AmazonS3Config GetClientConfig(Configuration configuration)
+    {
+        if (string.IsNullOrWhiteSpace(configuration.AccessKey))
+            throw new ArgumentException("Access key is required");
+
+        if (string.IsNullOrWhiteSpace(configuration.AccessSecret))
+            throw new ArgumentException("Access secret is required");
+
+        if (string.IsNullOrWhiteSpace(configuration.Bucket))
+            throw new ArgumentException("Bucket name is required");
+
+        var s3Cfg = new AmazonS3Config
+        {
+            RegionEndpoint = RegionEndpoint.GetBySystemName(configuration.Region),
+            RetryMode = RequestRetryMode.Adaptive,
+            ForcePathStyle = configuration.ForcePathStyle,
+        };
+        if (!string.IsNullOrWhiteSpace(configuration.Server))
+        {
+            // ServiceURL and RegionEndpoint are mutually exclusive; keep Region as the signing region
+            s3Cfg.ServiceURL = configuration.Server;
+            s3Cfg.AuthenticationRegion = configuration.Region;
+        }
+
+        return s3Cfg;
     }
 
     /// <summary>

--- a/base/Storage/tests/Annium.Storage.Abstractions.Tests/.gitignore
+++ b/base/Storage/tests/Annium.Storage.Abstractions.Tests/.gitignore
@@ -1,0 +1,6 @@
+# build
+/bin/
+/obj/
+
+# packages
+/*.nupkg

--- a/base/Storage/tests/Annium.Storage.Abstractions.Tests/Annium.Storage.Abstractions.Tests.csproj
+++ b/base/Storage/tests/Annium.Storage.Abstractions.Tests/Annium.Storage.Abstractions.Tests.csproj
@@ -7,13 +7,12 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="../../src/Annium.Storage.S3/Annium.Storage.S3.csproj" />
-    <ProjectReference Include="../Annium.Storage.Tests.Lib/Annium.Storage.Tests.Lib.csproj" />
+    <ProjectReference Include="../../src/Annium.Storage.Abstractions/Annium.Storage.Abstractions.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Annium.Testing" />
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Testcontainers.Minio" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="xunit.v3" />
   </ItemGroup>

--- a/base/Storage/tests/Annium.Storage.Abstractions.Tests/StorageHelperTest.cs
+++ b/base/Storage/tests/Annium.Storage.Abstractions.Tests/StorageHelperTest.cs
@@ -1,0 +1,210 @@
+using System;
+using Annium.Testing;
+using Xunit;
+
+namespace Annium.Storage.Abstractions.Tests;
+
+/// <summary>
+/// Tests for the shared path-validation helper. Every storage provider validates through it,
+/// so its accept/reject boundaries are the contract all of them inherit.
+/// </summary>
+public class StorageHelperTest
+{
+    /// <summary>
+    /// Tests that the bucket root is accepted as a root.
+    /// </summary>
+    [Fact]
+    public void VerifyRoot_Root_Passes()
+    {
+        // assert: does not throw
+        StorageHelper.VerifyRoot("/");
+    }
+
+    /// <summary>
+    /// Tests that an absolute, non-trailing-slash directory is accepted as a root.
+    /// </summary>
+    [Fact]
+    public void VerifyRoot_AbsoluteDirectory_Passes()
+    {
+        // assert: does not throw
+        StorageHelper.VerifyRoot("/files/nested");
+    }
+
+    /// <summary>
+    /// Tests that a relative root is rejected, since a root must be absolute.
+    /// </summary>
+    [Fact]
+    public void VerifyRoot_Relative_ThrowsArgumentException()
+    {
+        // assert
+        Wrap.It(() => StorageHelper.VerifyRoot("files")).Throws<ArgumentException>();
+    }
+
+    /// <summary>
+    /// Tests that a root with a trailing slash is rejected.
+    /// </summary>
+    [Fact]
+    public void VerifyRoot_TrailingSlash_ThrowsArgumentException()
+    {
+        // assert
+        Wrap.It(() => StorageHelper.VerifyRoot("/files/")).Throws<ArgumentException>();
+    }
+
+    /// <summary>
+    /// Tests that a root with a malformed part is rejected.
+    /// </summary>
+    [Fact]
+    public void VerifyRoot_InvalidPart_ThrowsArgumentException()
+    {
+        // assert
+        Wrap.It(() => StorageHelper.VerifyRoot("/files/..")).Throws<ArgumentException>();
+    }
+
+    /// <summary>
+    /// Tests that an empty prefix is accepted, since it means "no filtering".
+    /// </summary>
+    [Fact]
+    public void VerifyPrefix_Empty_Passes()
+    {
+        // assert: does not throw
+        StorageHelper.VerifyPrefix("");
+    }
+
+    /// <summary>
+    /// Tests that a relative, non-trailing-slash prefix is accepted.
+    /// </summary>
+    [Fact]
+    public void VerifyPrefix_Relative_Passes()
+    {
+        // assert: does not throw
+        StorageHelper.VerifyPrefix("files/nested");
+    }
+
+    /// <summary>
+    /// Tests that an absolute prefix is rejected, since a prefix is relative to the root.
+    /// </summary>
+    [Fact]
+    public void VerifyPrefix_Absolute_ThrowsArgumentException()
+    {
+        // assert
+        Wrap.It(() => StorageHelper.VerifyPrefix("/files")).Throws<ArgumentException>();
+    }
+
+    /// <summary>
+    /// Tests that a prefix with a trailing slash is rejected.
+    /// </summary>
+    [Fact]
+    public void VerifyPrefix_TrailingSlash_ThrowsArgumentException()
+    {
+        // assert
+        Wrap.It(() => StorageHelper.VerifyPrefix("files/")).Throws<ArgumentException>();
+    }
+
+    /// <summary>
+    /// Tests that a prefix with a malformed part is rejected.
+    /// </summary>
+    [Fact]
+    public void VerifyPrefix_InvalidPart_ThrowsArgumentException()
+    {
+        // assert
+        Wrap.It(() => StorageHelper.VerifyPrefix("files/..")).Throws<ArgumentException>();
+    }
+
+    /// <summary>
+    /// Tests that a relative, non-trailing-slash path is accepted.
+    /// </summary>
+    [Fact]
+    public void VerifyPath_Relative_Passes()
+    {
+        // assert: does not throw
+        StorageHelper.VerifyPath("files/nested.txt");
+    }
+
+    /// <summary>
+    /// Tests that an empty path is rejected, since every operation needs a target.
+    /// </summary>
+    [Fact]
+    public void VerifyPath_Empty_ThrowsArgumentException()
+    {
+        // assert
+        Wrap.It(() => StorageHelper.VerifyPath("")).Throws<ArgumentException>();
+    }
+
+    /// <summary>
+    /// Tests that an absolute path is rejected, since a path is relative to the root.
+    /// </summary>
+    [Fact]
+    public void VerifyPath_Absolute_ThrowsArgumentException()
+    {
+        // assert
+        Wrap.It(() => StorageHelper.VerifyPath("/files.txt")).Throws<ArgumentException>();
+    }
+
+    /// <summary>
+    /// Tests that a path with a trailing slash is rejected, since it names a directory, not a file.
+    /// </summary>
+    [Fact]
+    public void VerifyPath_TrailingSlash_ThrowsArgumentException()
+    {
+        // assert
+        Wrap.It(() => StorageHelper.VerifyPath("files/")).Throws<ArgumentException>();
+    }
+
+    /// <summary>
+    /// Tests that a path with a malformed part is rejected.
+    /// </summary>
+    [Fact]
+    public void VerifyPath_InvalidPart_ThrowsArgumentException()
+    {
+        // assert
+        Wrap.It(() => StorageHelper.VerifyPath(".")).Throws<ArgumentException>();
+    }
+
+    /// <summary>
+    /// Tests that names may contain an underscore anywhere, including leading and trailing.
+    /// </summary>
+    /// <param name="path">The path expected to be accepted.</param>
+    [Theory]
+    [InlineData("_leading")]
+    [InlineData("trailing_")]
+    [InlineData("in_the_middle")]
+    [InlineData("_")]
+    [InlineData(".hidden")]
+    [InlineData("dashed-name")]
+    [InlineData("dotted.name")]
+    public void VerifyPath_AllowedName_Passes(string path)
+    {
+        // assert: does not throw
+        StorageHelper.VerifyPath(path);
+    }
+
+    /// <summary>
+    /// Tests that a part containing punctuation is rejected. These characters all sit between Z and a
+    /// in ASCII, so a name pattern written A-z rather than A-Za-z would wrongly accept them —
+    /// the backslash among them separates directories on Windows, letting a part escape the root.
+    /// </summary>
+    /// <param name="path">The path expected to be rejected.</param>
+    [Theory]
+    [InlineData(@"back\slash")]
+    [InlineData(@"back\..\..\escape")]
+    [InlineData("caret^name")]
+    [InlineData("tick`name")]
+    [InlineData("bracket[name")]
+    [InlineData("bracket]name")]
+    public void VerifyPath_PunctuationInPart_ThrowsArgumentException(string path)
+    {
+        // assert
+        Wrap.It(() => StorageHelper.VerifyPath(path)).Throws<ArgumentException>();
+    }
+
+    /// <summary>
+    /// Tests that the same punctuation is rejected in a root and in a prefix, not just in a path.
+    /// </summary>
+    [Fact]
+    public void VerifyRootAndPrefix_PunctuationInPart_ThrowsArgumentException()
+    {
+        // assert
+        Wrap.It(() => StorageHelper.VerifyRoot(@"/back\..\escape")).Throws<ArgumentException>();
+        Wrap.It(() => StorageHelper.VerifyPrefix(@"back\..\escape")).Throws<ArgumentException>();
+    }
+}

--- a/base/Storage/tests/Annium.Storage.FileSystem.Tests/ConfigurationTest.cs
+++ b/base/Storage/tests/Annium.Storage.FileSystem.Tests/ConfigurationTest.cs
@@ -1,0 +1,65 @@
+using System;
+using Annium.Core.DependencyInjection;
+using Annium.Core.Runtime;
+using Annium.Logging.InMemory;
+using Annium.Logging.Shared;
+using Annium.Storage.Abstractions;
+using Annium.Testing;
+using Xunit;
+
+namespace Annium.Storage.FileSystem.Tests;
+
+/// <summary>
+/// Tests for the file system configuration guards, which reject a malformed root directory
+/// on construction, before any storage operation is attempted.
+/// </summary>
+public class ConfigurationTest
+{
+    /// <summary>
+    /// Tests that a root directory that is not absolute is rejected.
+    /// </summary>
+    [Fact]
+    public void RelativeDirectory_ThrowsArgumentException()
+    {
+        // assert
+        Wrap.It(() => GetStorage("files")).Throws<ArgumentException>();
+    }
+
+    /// <summary>
+    /// Tests that a root directory with a trailing slash is rejected.
+    /// </summary>
+    [Fact]
+    public void TrailingSlashDirectory_ThrowsArgumentException()
+    {
+        // assert
+        Wrap.It(() => GetStorage("/files/")).Throws<ArgumentException>();
+    }
+
+    /// <summary>
+    /// Tests that a root directory with a malformed segment is rejected.
+    /// </summary>
+    [Fact]
+    public void InvalidDirectoryPart_ThrowsArgumentException()
+    {
+        // assert
+        Wrap.It(() => GetStorage("/files/..")).Throws<ArgumentException>();
+    }
+
+    /// <summary>
+    /// Creates a file system storage instance rooted at the given directory.
+    /// </summary>
+    /// <param name="directory">The root directory under test.</param>
+    /// <returns>A configured file system storage instance.</returns>
+    private static IStorage GetStorage(string directory)
+    {
+        var services = new ServiceContainer();
+        services.AddLogging();
+        services.AddTime().WithManagedTime().SetDefault();
+        services.AddFileSystemStorage("default", (_, _) => new Configuration { Directory = directory }, true);
+
+        var provider = services.BuildServiceProvider();
+        provider.UseLogging(x => x.UseInMemory());
+
+        return provider.Resolve<IStorage>();
+    }
+}

--- a/base/Storage/tests/Annium.Storage.FileSystem.Tests/ConfigurationTest.cs
+++ b/base/Storage/tests/Annium.Storage.FileSystem.Tests/ConfigurationTest.cs
@@ -1,9 +1,6 @@
 using System;
-using Annium.Core.DependencyInjection;
-using Annium.Core.Runtime;
-using Annium.Logging.InMemory;
-using Annium.Logging.Shared;
 using Annium.Storage.Abstractions;
+using Annium.Storage.Tests.Lib;
 using Annium.Testing;
 using Xunit;
 
@@ -50,16 +47,8 @@ public class ConfigurationTest
     /// </summary>
     /// <param name="directory">The root directory under test.</param>
     /// <returns>A configured file system storage instance.</returns>
-    private static IStorage GetStorage(string directory)
-    {
-        var services = new ServiceContainer();
-        services.AddLogging();
-        services.AddTime().WithManagedTime().SetDefault();
-        services.AddFileSystemStorage("default", (_, _) => new Configuration { Directory = directory }, true);
-
-        var provider = services.BuildServiceProvider();
-        provider.UseLogging(x => x.UseInMemory());
-
-        return provider.Resolve<IStorage>();
-    }
+    private static IStorage GetStorage(string directory) =>
+        TestServices.BuildStorage(services =>
+            services.AddFileSystemStorage("default", (_, _) => new Configuration { Directory = directory }, true)
+        );
 }

--- a/base/Storage/tests/Annium.Storage.FileSystem.Tests/StorageTest.cs
+++ b/base/Storage/tests/Annium.Storage.FileSystem.Tests/StorageTest.cs
@@ -1,10 +1,6 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
-using Annium.Core.DependencyInjection;
-using Annium.Core.Runtime;
-using Annium.Logging.InMemory;
-using Annium.Logging.Shared;
 using Annium.Storage.Abstractions;
 using Annium.Storage.Tests.Lib;
 
@@ -28,16 +24,11 @@ public class StorageTest : StorageTestBase, IAsyncDisposable
     /// <returns>A configured file system storage instance.</returns>
     protected override IStorage GetStorage()
     {
-        var services = new ServiceContainer();
-        services.AddLogging();
-        services.AddTime().WithManagedTime().SetDefault();
         Directory.CreateDirectory(_directory);
-        services.AddFileSystemStorage("default", (_, _) => new Configuration { Directory = _directory }, true);
 
-        var provider = services.BuildServiceProvider();
-        provider.UseLogging(x => x.UseInMemory());
-
-        return provider.Resolve<IStorage>();
+        return TestServices.BuildStorage(services =>
+            services.AddFileSystemStorage("default", (_, _) => new Configuration { Directory = _directory }, true)
+        );
     }
 
     /// <summary>

--- a/base/Storage/tests/Annium.Storage.InMemory.Tests/StorageTest.cs
+++ b/base/Storage/tests/Annium.Storage.InMemory.Tests/StorageTest.cs
@@ -1,9 +1,10 @@
-using Annium.Core.DependencyInjection;
-using Annium.Core.Runtime;
-using Annium.Logging.InMemory;
-using Annium.Logging.Shared;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 using Annium.Storage.Abstractions;
 using Annium.Storage.Tests.Lib;
+using Annium.Testing;
+using Xunit;
 
 namespace Annium.Storage.InMemory.Tests;
 
@@ -14,20 +15,46 @@ namespace Annium.Storage.InMemory.Tests;
 public class StorageTest : StorageTestBase
 {
     /// <summary>
+    /// Tests that when callers race to delete one item, exactly one of them is told it did the
+    /// deleting — so a caller can act on having removed it without two callers both acting.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task Delete_Concurrent_ReportsSuccessOnce()
+    {
+        // arrange: racers all released at once, to have them contend for the same item
+        const int racers = 16;
+        var storage = GetStorage();
+        await storage.UploadAsync(new MemoryStream("sample text file"u8.ToArray()), "delete_concurrent");
+
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var deletes = Enumerable
+            .Range(0, racers)
+            .Select(_ =>
+                Task.Run(async () =>
+                {
+#pragma warning disable VSTHRD003 // intentionally awaiting the shared release barrier from within the racer
+                    await gate.Task;
+#pragma warning restore VSTHRD003
+
+                    return await storage.DeleteAsync("delete_concurrent");
+                })
+            )
+            .ToArray();
+
+        // act
+        gate.SetResult();
+        var results = await Task.WhenAll(deletes);
+
+        // assert
+        results.Count(x => x).Is(1);
+    }
+
+    /// <summary>
     /// Creates and configures an in-memory storage instance for testing.
     /// Sets up dependency injection container with in-memory storage provider.
     /// </summary>
     /// <returns>A configured in-memory storage instance.</returns>
-    protected override IStorage GetStorage()
-    {
-        var services = new ServiceContainer();
-        services.AddLogging();
-        services.AddTime().WithManagedTime().SetDefault();
-        services.AddInMemoryStorage("default", true);
-
-        var provider = services.BuildServiceProvider();
-        provider.UseLogging(x => x.UseInMemory());
-
-        return provider.Resolve<IStorage>();
-    }
+    protected override IStorage GetStorage() =>
+        TestServices.BuildStorage(services => services.AddInMemoryStorage("default", true));
 }

--- a/base/Storage/tests/Annium.Storage.S3.Tests/ClientConfigTest.cs
+++ b/base/Storage/tests/Annium.Storage.S3.Tests/ClientConfigTest.cs
@@ -1,0 +1,64 @@
+using Amazon;
+using Annium.Testing;
+using Xunit;
+
+namespace Annium.Storage.S3.Tests;
+
+/// <summary>
+/// Tests for how the S3 client is pointed at a server, covering the AWS endpoint the container-backed
+/// suites never reach.
+/// </summary>
+public class ClientConfigTest
+{
+    /// <summary>
+    /// Tests that a configured server is addressed directly, with the region kept as the signing
+    /// region rather than as the endpoint.
+    /// </summary>
+    [Fact]
+    public void GetClientConfig_Server_TargetsServer()
+    {
+        // arrange
+        var configuration = GetConfiguration() with
+        {
+            Server = "http://localhost:9000",
+        };
+
+        // act
+        var config = Internal.Storage.GetClientConfig(configuration);
+
+        // assert: the SDK normalizes the endpoint with a trailing slash
+        config.ServiceURL.Is("http://localhost:9000/");
+        config.AuthenticationRegion.Is("us-east-1");
+    }
+
+    /// <summary>
+    /// Tests that with no server configured the client is left to address AWS itself by region —
+    /// the path a live cloud account uses, which no test server stands in for.
+    /// </summary>
+    [Fact]
+    public void GetClientConfig_NoServer_TargetsAwsRegion()
+    {
+        // arrange
+        var configuration = GetConfiguration();
+
+        // act
+        var config = Internal.Storage.GetClientConfig(configuration);
+
+        // assert: no endpoint of our own, leaving the SDK to address AWS by region
+        config.ServiceURL.IsDefault();
+        config.RegionEndpoint.Is(RegionEndpoint.GetBySystemName("us-east-1"));
+    }
+
+    /// <summary>
+    /// Creates a configuration that passes the guards, leaving the server unset.
+    /// </summary>
+    /// <returns>A valid configuration with no server.</returns>
+    private static Configuration GetConfiguration() =>
+        new()
+        {
+            AccessKey = "access-key",
+            AccessSecret = "access-secret",
+            Region = "us-east-1",
+            Bucket = "bucket",
+        };
+}

--- a/base/Storage/tests/Annium.Storage.S3.Tests/ConfigurationTest.cs
+++ b/base/Storage/tests/Annium.Storage.S3.Tests/ConfigurationTest.cs
@@ -1,0 +1,116 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Annium.Core.DependencyInjection;
+using Annium.Core.Runtime;
+using Annium.Logging.InMemory;
+using Annium.Logging.Shared;
+using Annium.Storage.Abstractions;
+using Annium.Testing;
+using Xunit;
+
+namespace Annium.Storage.S3.Tests;
+
+/// <summary>
+/// Tests for the S3 configuration guards, which reject an incomplete or malformed configuration
+/// before any request reaches the server. These need no backend, so they are kept out of the
+/// MinIO-backed suites.
+/// </summary>
+public class ConfigurationTest
+{
+    /// <summary>
+    /// Tests that a configuration without an access key is rejected.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task MissingAccessKey_ThrowsArgumentException()
+    {
+        // arrange
+        var storage = GetStorage(new Configuration { AccessSecret = "secret", Bucket = "bucket" });
+
+        // assert
+        await Wrap.It(async () => await storage.ListAsync())
+            .ThrowsAsync<ArgumentException>()
+            .ReportsExactlyAsync("Access key is required");
+    }
+
+    /// <summary>
+    /// Tests that a configuration without an access secret is rejected.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task MissingAccessSecret_ThrowsArgumentException()
+    {
+        // arrange
+        var storage = GetStorage(new Configuration { AccessKey = "key", Bucket = "bucket" });
+
+        // assert
+        await Wrap.It(async () => await storage.UploadAsync(new MemoryStream([1]), "upload_test"))
+            .ThrowsAsync<ArgumentException>()
+            .ReportsExactlyAsync("Access secret is required");
+    }
+
+    /// <summary>
+    /// Tests that a configuration without a bucket is rejected.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task MissingBucket_ThrowsArgumentException()
+    {
+        // arrange
+        var storage = GetStorage(new Configuration { AccessKey = "key", AccessSecret = "secret" });
+
+        // assert
+        await Wrap.It(async () => await storage.DeleteAsync("delete_test"))
+            .ThrowsAsync<ArgumentException>()
+            .ReportsExactlyAsync("Bucket name is required");
+    }
+
+    /// <summary>
+    /// Tests that a configuration whose directory is not absolute is rejected on construction,
+    /// before any storage operation is attempted.
+    /// </summary>
+    [Fact]
+    public void RelativeDirectory_ThrowsArgumentException()
+    {
+        // assert
+        Wrap.It(() => GetStorage(new Configuration { Bucket = "bucket", Directory = "files" }))
+            .Throws<ArgumentException>();
+    }
+
+    /// <summary>
+    /// Tests that a configuration whose directory has a trailing slash is rejected on construction.
+    /// </summary>
+    [Fact]
+    public void TrailingSlashDirectory_ThrowsArgumentException()
+    {
+        // assert
+        Wrap.It(() => GetStorage(new Configuration { Bucket = "bucket", Directory = "/files/" }))
+            .Throws<ArgumentException>();
+    }
+
+    /// <summary>
+    /// Creates an S3 storage instance from the given configuration, defaulting only the region and,
+    /// when the test does not set one, the directory — so each test trips exactly the guard it targets.
+    /// </summary>
+    /// <param name="configuration">The configuration under test.</param>
+    /// <returns>A configured S3 storage instance.</returns>
+    private static IStorage GetStorage(Configuration configuration)
+    {
+        var config = configuration with
+        {
+            Region = "us-east-1",
+            Directory = configuration.Directory == string.Empty ? "/" : configuration.Directory,
+        };
+
+        var services = new ServiceContainer();
+        services.AddLogging();
+        services.AddTime().WithManagedTime().SetDefault();
+        services.AddS3Storage("default", (_, _) => config, true);
+
+        var provider = services.BuildServiceProvider();
+        provider.UseLogging(x => x.UseInMemory());
+
+        return provider.Resolve<IStorage>();
+    }
+}

--- a/base/Storage/tests/Annium.Storage.S3.Tests/ConfigurationTest.cs
+++ b/base/Storage/tests/Annium.Storage.S3.Tests/ConfigurationTest.cs
@@ -1,11 +1,8 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
-using Annium.Core.DependencyInjection;
-using Annium.Core.Runtime;
-using Annium.Logging.InMemory;
-using Annium.Logging.Shared;
 using Annium.Storage.Abstractions;
+using Annium.Storage.Tests.Lib;
 using Annium.Testing;
 using Xunit;
 
@@ -103,14 +100,6 @@ public class ConfigurationTest
             Directory = configuration.Directory == string.Empty ? "/" : configuration.Directory,
         };
 
-        var services = new ServiceContainer();
-        services.AddLogging();
-        services.AddTime().WithManagedTime().SetDefault();
-        services.AddS3Storage("default", (_, _) => config, true);
-
-        var provider = services.BuildServiceProvider();
-        provider.UseLogging(x => x.UseInMemory());
-
-        return provider.Resolve<IStorage>();
+        return TestServices.BuildStorage(services => services.AddS3Storage("default", (_, _) => config, true));
     }
 }

--- a/base/Storage/tests/Annium.Storage.S3.Tests/RootStorageTest.cs
+++ b/base/Storage/tests/Annium.Storage.S3.Tests/RootStorageTest.cs
@@ -1,0 +1,18 @@
+namespace Annium.Storage.S3.Tests;
+
+/// <summary>
+/// Runs the common storage suite against the S3 provider configured at the bucket root,
+/// exercising the key-mapping branch where object keys are used verbatim with no directory prefix.
+/// </summary>
+public class RootStorageTest : S3StorageTestBase
+{
+    /// <summary>
+    /// The bucket this suite operates in. Distinct from the prefixed suite's bucket so the two stay isolated.
+    /// </summary>
+    protected override string Bucket => "annium-tests-root";
+
+    /// <summary>
+    /// The bucket root, meaning keys are stored without a directory prefix.
+    /// </summary>
+    protected override string Root => "/";
+}

--- a/base/Storage/tests/Annium.Storage.S3.Tests/S3StorageTestBase.cs
+++ b/base/Storage/tests/Annium.Storage.S3.Tests/S3StorageTestBase.cs
@@ -1,0 +1,212 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.Runtime;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Annium.Core.DependencyInjection;
+using Annium.Core.Runtime;
+using Annium.Logging.InMemory;
+using Annium.Logging.Shared;
+using Annium.Storage.Abstractions;
+using Annium.Storage.Tests.Lib;
+using Annium.Testing;
+using Testcontainers.Minio;
+using Xunit;
+
+namespace Annium.Storage.S3.Tests;
+
+/// <summary>
+/// Base for S3 storage tests, backed by a MinIO container so the suite needs no live cloud
+/// endpoint or credentials. Each concrete suite owns a distinct bucket, so suites stay isolated
+/// while sharing one container.
+/// </summary>
+public abstract class S3StorageTestBase : StorageTestBase, IAsyncLifetime
+{
+    /// <summary>
+    /// Guards lazy creation of the assembly-wide MinIO container.
+    /// </summary>
+    private static readonly SemaphoreSlim _gate = new(1, 1);
+
+    /// <summary>
+    /// The MinIO container shared by every test in this assembly, started on first use.
+    /// </summary>
+    private static MinioContainer? _container;
+
+    /// <summary>
+    /// The S3 configuration pointing at the started MinIO container.
+    /// </summary>
+    private Configuration _configuration = new();
+
+    /// <summary>
+    /// The bucket this suite operates in. Distinct per suite to keep suites isolated.
+    /// </summary>
+    protected abstract string Bucket { get; }
+
+    /// <summary>
+    /// The directory prefix within the bucket this suite stores under.
+    /// </summary>
+    protected abstract string Root { get; }
+
+    /// <summary>
+    /// Starts the shared MinIO container (once per assembly) and ensures this suite's bucket exists.
+    /// </summary>
+    /// <returns>A ValueTask representing the asynchronous initialization.</returns>
+    public async ValueTask InitializeAsync()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        await _gate.WaitAsync(ct);
+        try
+        {
+            if (_container is null)
+            {
+                // Testcontainers' default MinIO (RELEASE.2023-01-31) predates the request checksums
+                // AWSSDK v4 sends by default and rejects them; this release understands them
+                var container = new MinioBuilder("minio/minio:RELEASE.2025-09-07T16-13-09Z").Build();
+                await container.StartAsync(ct);
+                _container = container;
+            }
+        }
+        finally
+        {
+            _gate.Release();
+        }
+
+        _configuration = new Configuration
+        {
+            Server = _container.GetConnectionString(),
+            AccessKey = _container.GetAccessKey(),
+            AccessSecret = _container.GetSecretKey(),
+            Region = "us-east-1",
+            Bucket = Bucket,
+            Directory = Root,
+            ForcePathStyle = true,
+        };
+
+        using var s3 = GetRawClient();
+        try
+        {
+            await s3.PutBucketAsync(new PutBucketRequest { BucketName = Bucket }, ct);
+        }
+        catch (AmazonS3Exception e) when (e.ErrorCode is "BucketAlreadyOwnedByYou" or "BucketAlreadyExists")
+        {
+            // bucket survives from an earlier test in this suite — reuse it
+        }
+    }
+
+    /// <summary>
+    /// Tests that listing returns every stored item, including past the page size the S3 API
+    /// returns per request.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task List_BeyondSinglePage_ReturnsAll()
+    {
+        // arrange: more items than a page holds, so listing must follow the continuation
+        const int pageSize = 10;
+        const int count = 25;
+        var storage = GetStorage(_configuration with { PageSize = pageSize });
+        for (var i = 0; i < count; i++)
+            await storage.UploadAsync(new MemoryStream([(byte)i]), $"list_paged/{i:D3}");
+
+        // act
+        var keys = await storage.ListAsync("list_paged");
+
+        // assert
+        keys.Has(count);
+    }
+
+    /// <summary>
+    /// Creates and configures an S3 storage instance for testing.
+    /// Sets up dependency injection container with S3 storage provider and the MinIO-backed configuration.
+    /// </summary>
+    /// <returns>A configured S3 storage instance.</returns>
+    /// <summary>
+    /// Tests that a failed download request surfaces as itself, rather than being reported as a
+    /// missing item — the caller must be able to tell "not there" from "the request did not work".
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task Download_RequestRejected_SurfacesError()
+    {
+        // arrange: credentials that pass the configuration guards but the server refuses
+        var storage = GetStorage(_configuration with { AccessSecret = "wrong-secret" });
+
+        // assert
+        await Wrap.It(async () => await storage.DownloadAsync("download_rejected")).ThrowsAsync<AmazonS3Exception>();
+    }
+
+    /// <summary>
+    /// Tests that a failed delete request surfaces as itself, rather than being reported as a
+    /// missing item by returning false.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task Delete_RequestRejected_SurfacesError()
+    {
+        // arrange: credentials that pass the configuration guards but the server refuses
+        var storage = GetStorage(_configuration with { AccessSecret = "wrong-secret" });
+
+        // assert
+        await Wrap.It(async () => await storage.DeleteAsync("delete_rejected")).ThrowsAsync<AmazonS3Exception>();
+    }
+
+    /// <summary>
+    /// Creates and configures an S3 storage instance for testing, using this suite's MinIO-backed configuration.
+    /// </summary>
+    /// <returns>A configured S3 storage instance.</returns>
+    protected override IStorage GetStorage() => GetStorage(_configuration);
+
+    /// <summary>
+    /// Creates an S3 storage instance from the given configuration, letting a test vary it.
+    /// </summary>
+    /// <param name="configuration">The configuration to build the storage from.</param>
+    /// <returns>A configured S3 storage instance.</returns>
+    private static IStorage GetStorage(Configuration configuration)
+    {
+        var config = configuration;
+
+        var services = new ServiceContainer();
+        services.AddLogging();
+        services.AddTime().WithManagedTime().SetDefault();
+        services.AddS3Storage("default", (_, _) => config, true);
+
+        var provider = services.BuildServiceProvider();
+        provider.UseLogging(x => x.UseInMemory());
+
+        return provider.Resolve<IStorage>();
+    }
+
+    /// <summary>
+    /// Cleans up all test data from this suite's bucket, so each test observes only what it stored.
+    /// The container itself is reaped by the Testcontainers Ryuk sidecar at process exit.
+    /// </summary>
+    /// <returns>A ValueTask representing the asynchronous cleanup operation.</returns>
+    public async ValueTask DisposeAsync()
+    {
+        GC.SuppressFinalize(this);
+
+        var storage = GetStorage();
+        foreach (var item in await storage.ListAsync())
+            await storage.DeleteAsync(item);
+    }
+
+    /// <summary>
+    /// Creates a raw S3 client against the MinIO container, used for bucket provisioning.
+    /// </summary>
+    /// <returns>An AmazonS3Client bound to the container.</returns>
+    private AmazonS3Client GetRawClient()
+    {
+        var credentials = new BasicAWSCredentials(_configuration.AccessKey, _configuration.AccessSecret);
+        var s3Cfg = new AmazonS3Config
+        {
+            ServiceURL = _configuration.Server,
+            AuthenticationRegion = _configuration.Region,
+            ForcePathStyle = true,
+        };
+
+        return new AmazonS3Client(credentials, s3Cfg);
+    }
+}

--- a/base/Storage/tests/Annium.Storage.S3.Tests/S3StorageTestBase.cs
+++ b/base/Storage/tests/Annium.Storage.S3.Tests/S3StorageTestBase.cs
@@ -1,14 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Amazon.Runtime;
 using Amazon.S3;
 using Amazon.S3.Model;
-using Annium.Core.DependencyInjection;
-using Annium.Core.Runtime;
-using Annium.Logging.InMemory;
-using Annium.Logging.Shared;
 using Annium.Storage.Abstractions;
 using Annium.Storage.Tests.Lib;
 using Annium.Testing;
@@ -119,11 +116,6 @@ public abstract class S3StorageTestBase : StorageTestBase, IAsyncLifetime
     }
 
     /// <summary>
-    /// Creates and configures an S3 storage instance for testing.
-    /// Sets up dependency injection container with S3 storage provider and the MinIO-backed configuration.
-    /// </summary>
-    /// <returns>A configured S3 storage instance.</returns>
-    /// <summary>
     /// Tests that a failed download request surfaces as itself, rather than being reported as a
     /// missing item — the caller must be able to tell "not there" from "the request did not work".
     /// </summary>
@@ -154,6 +146,40 @@ public abstract class S3StorageTestBase : StorageTestBase, IAsyncLifetime
     }
 
     /// <summary>
+    /// Tests that a bucket that is not there reads as the item being absent, the same as a missing
+    /// item in a bucket that exists — the caller asked for something that is not in storage either way.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task Download_MissingBucket_ThrowsKeyNotFoundException()
+    {
+        // arrange: a bucket no suite provisions
+        var storage = GetStorage(_configuration with { Bucket = "missing-bucket-never-provisioned" });
+
+        // assert
+        await Wrap.It(async () => await storage.DownloadAsync("download_missing_bucket"))
+            .ThrowsAsync<KeyNotFoundException>();
+    }
+
+    /// <summary>
+    /// Tests that deleting from a bucket that is not there reports nothing was deleted, rather than
+    /// surfacing the absent bucket as a failed request.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task Delete_MissingBucket_ReturnsFalse()
+    {
+        // arrange: a bucket no suite provisions
+        var storage = GetStorage(_configuration with { Bucket = "missing-bucket-never-provisioned" });
+
+        // act
+        var result = await storage.DeleteAsync("delete_missing_bucket");
+
+        // assert
+        result.IsFalse();
+    }
+
+    /// <summary>
     /// Creates and configures an S3 storage instance for testing, using this suite's MinIO-backed configuration.
     /// </summary>
     /// <returns>A configured S3 storage instance.</returns>
@@ -164,20 +190,8 @@ public abstract class S3StorageTestBase : StorageTestBase, IAsyncLifetime
     /// </summary>
     /// <param name="configuration">The configuration to build the storage from.</param>
     /// <returns>A configured S3 storage instance.</returns>
-    private static IStorage GetStorage(Configuration configuration)
-    {
-        var config = configuration;
-
-        var services = new ServiceContainer();
-        services.AddLogging();
-        services.AddTime().WithManagedTime().SetDefault();
-        services.AddS3Storage("default", (_, _) => config, true);
-
-        var provider = services.BuildServiceProvider();
-        provider.UseLogging(x => x.UseInMemory());
-
-        return provider.Resolve<IStorage>();
-    }
+    private static IStorage GetStorage(Configuration configuration) =>
+        TestServices.BuildStorage(services => services.AddS3Storage("default", (_, _) => configuration, true));
 
     /// <summary>
     /// Cleans up all test data from this suite's bucket, so each test observes only what it stored.

--- a/base/Storage/tests/Annium.Storage.S3.Tests/StorageTest.cs
+++ b/base/Storage/tests/Annium.Storage.S3.Tests/StorageTest.cs
@@ -1,55 +1,18 @@
-using System;
-using System.Threading.Tasks;
-using Annium.Core.DependencyInjection;
-using Annium.Core.Runtime;
-using Annium.Logging.InMemory;
-using Annium.Logging.Shared;
-using Annium.Storage.Abstractions;
-using Annium.Storage.Tests.Lib;
-
 namespace Annium.Storage.S3.Tests;
 
 /// <summary>
-/// Test class for S3-compatible storage implementation.
-/// Inherits from StorageTestBase to run common storage tests against the S3 provider.
+/// Runs the common storage suite against the S3 provider configured with a directory prefix,
+/// so object keys are mapped under that prefix within the bucket.
 /// </summary>
-internal class StorageTest : StorageTestBase, IAsyncDisposable
+public class StorageTest : S3StorageTestBase
 {
     /// <summary>
-    /// Creates and configures an S3 storage instance for testing.
-    /// Sets up dependency injection container with S3 storage provider and test configuration.
+    /// The bucket this suite operates in.
     /// </summary>
-    /// <returns>A configured S3 storage instance.</returns>
-    protected override IStorage GetStorage()
-    {
-        var services = new ServiceContainer();
-        services.AddLogging();
-        services.AddTime().WithManagedTime().SetDefault();
-        var config = new Configuration
-        {
-            Server = "https://s3.yandexcloud.net",
-            AccessKey = "AccessKey",
-            AccessSecret = "AccessSecret",
-            Region = "us-east-1",
-            Bucket = "annium.tests",
-            Directory = "/files",
-        };
-        services.AddS3Storage("default", (_, _) => config, true);
-
-        var provider = services.BuildServiceProvider();
-        provider.UseLogging(x => x.UseInMemory());
-
-        return provider.Resolve<IStorage>();
-    }
+    protected override string Bucket => "annium-tests";
 
     /// <summary>
-    /// Cleans up all test data from the S3 storage by deleting all stored items.
+    /// The directory prefix this suite stores under.
     /// </summary>
-    /// <returns>A ValueTask representing the asynchronous cleanup operation.</returns>
-    public async ValueTask DisposeAsync()
-    {
-        var storage = GetStorage();
-        foreach (var item in await storage.ListAsync())
-            await storage.DeleteAsync(item);
-    }
+    protected override string Root => "/files";
 }

--- a/base/Storage/tests/Annium.Storage.Tests.Lib/StorageTestBase.cs
+++ b/base/Storage/tests/Annium.Storage.Tests.Lib/StorageTestBase.cs
@@ -118,7 +118,100 @@ public abstract class StorageTestBase
     }
 
     /// <summary>
-    /// Tests that invalid item names are properly validated and rejected.
+    /// Tests that a prefix naming a stored item exactly matches that item, rather than only
+    /// matching items nested beneath it.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task List_ExactPrefix_MatchesItem()
+    {
+        // arrange
+        var storage = GetStorage();
+        var blob = GenerateBlob();
+        await storage.UploadAsync(new MemoryStream(blob), "list_exact");
+
+        // act
+        var keys = await storage.ListAsync("list_exact");
+
+        // assert
+        keys.Has(1);
+        keys.Contains("list_exact").IsTrue();
+    }
+
+    /// <summary>
+    /// Tests that uploading stores the whole stream, not only the part after wherever the caller
+    /// happened to leave its position.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task Upload_ReadSource_StoresWholeStream()
+    {
+        // arrange
+        var storage = GetStorage();
+        var blob = GenerateBlob();
+        var source = new MemoryStream(blob);
+        source.ReadByte();
+
+        // act
+        await storage.UploadAsync(source, "upload_read_source");
+        byte[] result;
+        using (var ms = new MemoryStream())
+        {
+            await (await storage.DownloadAsync("upload_read_source")).CopyToAsync(
+                ms,
+                TestContext.Current.CancellationToken
+            );
+            result = ms.ToArray();
+        }
+
+        // assert
+        result.SequenceEqual(blob).IsTrue();
+    }
+
+    /// <summary>
+    /// Tests that a prefix matches whole path segments, so an item merely starting with the same
+    /// characters is not treated as being under it.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task List_SimilarPrefix_NotMatched()
+    {
+        // arrange
+        var storage = GetStorage();
+        var blob = GenerateBlob();
+        await storage.UploadAsync(new MemoryStream(blob), "list_boundary/a");
+        await storage.UploadAsync(new MemoryStream(blob), "list_boundary_other/a");
+
+        // act
+        var keys = await storage.ListAsync("list_boundary");
+
+        // assert
+        keys.Has(1);
+        keys.Contains("list_boundary/a").IsTrue();
+    }
+
+    /// <summary>
+    /// Tests that listing a prefix nothing was stored under returns an empty result rather than failing.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task List_NoMatches_ReturnsEmpty()
+    {
+        // arrange
+        var storage = GetStorage();
+        var blob = GenerateBlob();
+        await storage.UploadAsync(new MemoryStream(blob), "list_nomatches/a");
+
+        // act
+        var keys = await storage.ListAsync("list_nomatches_other");
+
+        // assert
+        keys.IsEmpty();
+    }
+
+    /// <summary>
+    /// Tests that invalid item names are properly validated and rejected by every operation,
+    /// not just by a single representative one.
     /// </summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
     [Fact]
@@ -126,9 +219,14 @@ public abstract class StorageTestBase
     {
         // arrange
         var storage = GetStorage();
+        var blob = GenerateBlob();
 
         // assert
         await Wrap.It(async () => await storage.DownloadAsync(".")).ThrowsAsync<ArgumentException>();
+        await Wrap.It(async () => await storage.UploadAsync(new MemoryStream(blob), "."))
+            .ThrowsAsync<ArgumentException>();
+        await Wrap.It(async () => await storage.DeleteAsync(".")).ThrowsAsync<ArgumentException>();
+        await Wrap.It(async () => await storage.ListAsync("/absolute")).ThrowsAsync<ArgumentException>();
     }
 
     /// <summary>

--- a/base/Storage/tests/Annium.Storage.Tests.Lib/StorageTestBase.cs
+++ b/base/Storage/tests/Annium.Storage.Tests.Lib/StorageTestBase.cs
@@ -79,6 +79,37 @@ public abstract class StorageTestBase
     }
 
     /// <summary>
+    /// Tests that uploading over an item that is already stored replaces it, rather than keeping
+    /// what was there or storing both.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task Upload_ExistingKey_OverwritesValue()
+    {
+        // arrange
+        var storage = GetStorage();
+        await storage.UploadAsync(new MemoryStream(GenerateBlob()), "upload_existing");
+
+        // act: shorter than what it replaces, so a write that fails to truncate leaves a tail behind
+        var blob = "brief"u8.ToArray();
+        await storage.UploadAsync(new MemoryStream(blob), "upload_existing");
+
+        // assert
+        byte[] result;
+        using (var ms = new MemoryStream())
+        {
+            await (await storage.DownloadAsync("upload_existing")).CopyToAsync(
+                ms,
+                TestContext.Current.CancellationToken
+            );
+            result = ms.ToArray();
+        }
+
+        result.SequenceEqual(blob).IsTrue();
+        (await storage.ListAsync("upload_existing")).Has(1);
+    }
+
+    /// <summary>
     /// Tests that attempting to download a non-existent item throws a KeyNotFoundException.
     /// </summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>

--- a/base/Storage/tests/Annium.Storage.Tests.Lib/TestServices.cs
+++ b/base/Storage/tests/Annium.Storage.Tests.Lib/TestServices.cs
@@ -1,0 +1,32 @@
+using System;
+using Annium.Core.DependencyInjection;
+using Annium.Core.Runtime;
+using Annium.Logging.InMemory;
+using Annium.Logging.Shared;
+using Annium.Storage.Abstractions;
+
+namespace Annium.Storage.Tests.Lib;
+
+/// <summary>
+/// Shared wiring for storage test suites, so each suite states only which storage it is testing.
+/// </summary>
+public static class TestServices
+{
+    /// <summary>
+    /// Builds a storage instance, leaving the caller to register the storage under test.
+    /// </summary>
+    /// <param name="registerStorage">Registers the storage provider being tested.</param>
+    /// <returns>The registered storage instance.</returns>
+    public static IStorage BuildStorage(Action<IServiceContainer> registerStorage)
+    {
+        var services = new ServiceContainer();
+        services.AddLogging();
+        services.AddTime().WithManagedTime().SetDefault();
+        registerStorage(services);
+
+        var provider = services.BuildServiceProvider();
+        provider.UseLogging(x => x.UseInMemory());
+
+        return provider.Resolve<IStorage>();
+    }
+}


### PR DESCRIPTION
Annium.Storage.S3.Tests declared its class `internal`, so xunit discovered zero tests and CI reported green over an entirely unverified S3 provider. Back it with a MinIO container instead, so the suite needs no cloud endpoint or credentials, and fix what running it surfaced.

Bugs fixed:

- FileSystem ListAsync did not verify its prefix. Path.Combine drops the root when the prefix is absolute, so a prefix like "/etc" listed outside the configured root.
- StorageHelper's name pattern was written [A-z0-9], a range over ASCII 65-122 that also covers [ \ ] ^ _ `. A part could therefore contain a backslash, which separates directories on Windows, and escape the root.
- FileSystem ListAsync threw DirectoryNotFoundException for a prefix nothing was stored under, where the other storages return empty.
- FileSystem ListAsync skipped a prefix naming an item exactly, since Directory.Exists is false for a file.
- InMemory UploadAsync rewound the destination rather than the source, storing only the remainder of an already-read stream.
- InMemory DeleteAsync called Remove, which resolves to the IDictionary extension: it reads then removes non-atomically, so racing deleters were both told they had deleted the item.
- S3 ListAsync read one page and ignored IsTruncated, silently dropping items past the page size.
- S3 ListAsync dereferenced S3Objects, which is null rather than empty when nothing matches.
- S3 ListAsync matched the prefix as raw characters, so "reports" also matched "reports-archive/x", unlike the other storages.
- S3 Download/Delete caught every AmazonS3Exception, reporting a denied or failed request as a missing item and discarding the cause.

Configuration gains ForcePathStyle, without which the storage could not address any S3-compatible server despite documenting support for them, and PageSize, so listing can be exercised across pages without making production pay for small ones. Delete probes with a HEAD, which answers existence without fetching the body.

Tests go from 14 to 87, of which S3 accounts for 33 against MinIO; every fix above is pinned by one that fails without it.