### PR TITLE
fix(linq2db): manual-timestamp pipeline + PK-exclusion bugs, scope-le…

### DIFF
--- a/integrations/linq2db/src/Annium.linq2db.Extensions/Configuration/Extensions/MappingSchemaExtensionsBase.cs
+++ b/integrations/linq2db/src/Annium.linq2db.Extensions/Configuration/Extensions/MappingSchemaExtensionsBase.cs
@@ -81,6 +81,7 @@ public static class MappingSchemaExtensionsBase
     /// <param name="schema">The mapping schema to configure.</param>
     /// <param name="sp">The service provider containing entity configurations.</param>
     /// <returns>The configured mapping schema with all entity configurations applied.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when a registered configuration doesn't implement <see cref="IEntityConfiguration{TEntity}"/>.</exception>
     public static MappingSchema ApplyConfigurations(this MappingSchema schema, IServiceProvider sp)
     {
         var entityMappingBuilderFactory = typeof(FluentMappingBuilder).GetMethod(nameof(FluentMappingBuilder.Entity))!;

--- a/integrations/linq2db/src/Annium.linq2db.Extensions/Extensions/DataConnectionExtensions.cs
+++ b/integrations/linq2db/src/Annium.linq2db.Extensions/Extensions/DataConnectionExtensions.cs
@@ -1,7 +1,9 @@
+using System;
 using Annium.Data.Models;
 using Annium.linq2db.Extensions.Internal.Extensions;
 using LinqToDB.Data;
 using LinqToDB.Internal.SqlQuery;
+using LinqToDB.Mapping;
 
 // ReSharper disable once CheckNamespace
 namespace Annium.linq2db.Extensions;
@@ -46,33 +48,17 @@ public static class DataConnectionExtensions
         ITimeProvider timeProvider
     )
     {
-        // get data type
-        var dataType = statement.Insert.Into?.ObjectType;
-
-        // weird, but possible according to nullability spec
-        if (dataType is null)
+        var columns = cn.ResolveTimeColumns(statement.Insert.Into?.ObjectType);
+        if (columns is null)
             return statement;
-
-        // basic and fast way to ensure processability
-        if (!dataType.IsAssignableTo(typeof(ICreatedTimeEntity)))
-            return statement;
-
-        // get table schema descriptor
-        var descriptor = cn.MappingSchema.GetEntityDescriptor(dataType);
-
-        // resolve CreatedAt column descriptor
-        var createdTime = descriptor.Columns.FindColumn(nameof(ICreatedTimeEntity.CreatedAt));
-
-        // if source is additionally updatable
-        var updatedTime = dataType.IsAssignableTo(typeof(ICreatedUpdatedTimeEntity))
-            ? descriptor.Columns.FindColumn(nameof(ICreatedUpdatedTimeEntity.UpdatedAt))
-            : null;
+        var (createdTime, updatedTime) = columns.Value;
 
         var stmt = statement.CloneWithoutParams();
         var insert = stmt.Insert;
         var now = timeProvider.Now;
 
-        insert.SetValue(createdTime, now);
+        if (createdTime is not null)
+            insert.SetValue(createdTime, now);
 
         if (updatedTime is not null)
             insert.SetValue(updatedTime, now);
@@ -107,8 +93,10 @@ public static class DataConnectionExtensions
         // get table schema descriptor
         var descriptor = cn.MappingSchema.GetEntityDescriptor(dataType);
 
-        // resolve UpdatedAt column descriptor
-        var updatedTime = descriptor.Columns.FindColumn(nameof(ICreatedUpdatedTimeEntity.UpdatedAt));
+        // resolve UpdatedAt column descriptor; null when manually managed — leave the statement untouched
+        var updatedTime = descriptor.Columns.TryFindColumn(nameof(ICreatedUpdatedTimeEntity.UpdatedAt));
+        if (updatedTime is null)
+            return statement;
 
         var stmt = statement.CloneWithoutParams();
         var update = stmt.Update;
@@ -130,35 +118,22 @@ public static class DataConnectionExtensions
         ITimeProvider timeProvider
     )
     {
-        // get data type (generally it's impossible to have different tables in insert/update clauses, so simply use insert one to get object type)
-        var dataType = statement.Insert.Into?.ObjectType;
-
-        // weird, but possible according to nullability spec
-        if (dataType is null)
+        // generally it's impossible to have different tables in insert/update clauses, so simply use the insert one to get object type
+        var columns = cn.ResolveTimeColumns(statement.Insert.Into?.ObjectType);
+        if (columns is null)
             return statement;
-
-        // basic and fast way to ensure processability
-        if (!dataType.IsAssignableTo(typeof(ICreatedTimeEntity)))
-            return statement;
-
-        // get table schema descriptor
-        var descriptor = cn.MappingSchema.GetEntityDescriptor(dataType);
-
-        // resolve CreatedAt column descriptor
-        var createdTime = descriptor.Columns.FindColumn(nameof(ICreatedTimeEntity.CreatedAt));
-
-        // if source is additionally updatable
-        var updatedTime = dataType.IsAssignableTo(typeof(ICreatedUpdatedTimeEntity))
-            ? descriptor.Columns.FindColumn(nameof(ICreatedUpdatedTimeEntity.UpdatedAt))
-            : null;
+        var (createdTime, updatedTime) = columns.Value;
 
         var stmt = statement.CloneWithoutParams();
         var insert = stmt.Insert;
         var update = stmt.Update;
         var now = timeProvider.Now;
 
-        insert.SetValue(createdTime, now);
-        update.IgnoreValue(createdTime);
+        if (createdTime is not null)
+        {
+            insert.SetValue(createdTime, now);
+            update.IgnoreValue(createdTime);
+        }
 
         if (updatedTime is not null)
         {
@@ -167,5 +142,44 @@ public static class DataConnectionExtensions
         }
 
         return stmt;
+    }
+
+    /// <summary>
+    /// Resolves the created/updated time column descriptors for the given entity type, or null when the
+    /// type is not applicable for timestamp processing (null, or not an <see cref="ICreatedTimeEntity"/>).
+    /// </summary>
+    /// <param name="cn">The data connection.</param>
+    /// <param name="dataType">The entity type of the statement's target table.</param>
+    /// <returns>The CreatedAt descriptor plus an optional UpdatedAt descriptor, or null when not applicable.</returns>
+    private static (ColumnDescriptor? Created, ColumnDescriptor? Updated)? ResolveTimeColumns(
+        this DataConnection cn,
+        Type? dataType
+    )
+    {
+        // weird, but possible according to nullability spec
+        if (dataType is null)
+            return null;
+
+        // basic and fast way to ensure processability
+        if (!dataType.IsAssignableTo(typeof(ICreatedTimeEntity)))
+            return null;
+
+        // get table schema descriptor
+        var descriptor = cn.MappingSchema.GetEntityDescriptor(dataType);
+
+        // resolve the CreatedAt column descriptor; null when it is manually managed
+        // (ConfigureManualCreatedTime marks it skip-on-insert/update, so TryFindColumn excludes it)
+        var createdTime = descriptor.Columns.TryFindColumn(nameof(ICreatedTimeEntity.CreatedAt));
+
+        // if source is additionally updatable, resolve the UpdatedAt column descriptor (null when manual)
+        var updatedTime = dataType.IsAssignableTo(typeof(ICreatedUpdatedTimeEntity))
+            ? descriptor.Columns.TryFindColumn(nameof(ICreatedUpdatedTimeEntity.UpdatedAt))
+            : null;
+
+        // both timestamps are manually managed (skip-flagged) — nothing for the pipeline to auto-stamp
+        if (createdTime is null && updatedTime is null)
+            return null;
+
+        return (createdTime, updatedTime);
     }
 }

--- a/integrations/linq2db/src/Annium.linq2db.Extensions/Extensions/ServiceProviderConnectionScopeExtensions.cs
+++ b/integrations/linq2db/src/Annium.linq2db.Extensions/Extensions/ServiceProviderConnectionScopeExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using Annium.Core.DependencyInjection;
+using Annium.linq2db.Extensions.Internal.Extensions;
 using LinqToDB.Data;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -20,16 +21,33 @@ public static class ServiceProviderConnectionScopeExtensions
     public static ConnectionScope<T> GetConnectionScope<T>(this IServiceProvider sp)
         where T : DataConnection
     {
+        AsyncServiceScope scope;
         try
         {
-            var scope = sp.CreateAsyncScope();
+            scope = sp.CreateAsyncScope();
+        }
+        catch (ObjectDisposedException)
+        {
+            return new ConnectionScope<T>(true);
+        }
+
+        try
+        {
             var cn = scope.ServiceProvider.Resolve<T>();
 
             return new ConnectionScope<T>(scope, cn);
         }
         catch (ObjectDisposedException)
         {
+            scope.DisposeSafely();
             return new ConnectionScope<T>(true);
+        }
+        catch
+        {
+            // resolution failed after the scope was created — dispose it so the scope and any
+            // already-resolved scoped connection don't leak, then propagate
+            scope.DisposeSafely();
+            throw;
         }
     }
 
@@ -44,9 +62,18 @@ public static class ServiceProviderConnectionScopeExtensions
         where T1 : DataConnection
         where T2 : DataConnection
     {
+        AsyncServiceScope scope;
         try
         {
-            var scope = sp.CreateAsyncScope();
+            scope = sp.CreateAsyncScope();
+        }
+        catch (ObjectDisposedException)
+        {
+            return new ConnectionScope<T1, T2>(true);
+        }
+
+        try
+        {
             var cn1 = scope.ServiceProvider.Resolve<T1>();
             var cn2 = scope.ServiceProvider.Resolve<T2>();
 
@@ -54,7 +81,13 @@ public static class ServiceProviderConnectionScopeExtensions
         }
         catch (ObjectDisposedException)
         {
+            scope.DisposeSafely();
             return new ConnectionScope<T1, T2>(true);
+        }
+        catch
+        {
+            scope.DisposeSafely();
+            throw;
         }
     }
 
@@ -71,9 +104,18 @@ public static class ServiceProviderConnectionScopeExtensions
         where T2 : DataConnection
         where T3 : DataConnection
     {
+        AsyncServiceScope scope;
         try
         {
-            var scope = sp.CreateAsyncScope();
+            scope = sp.CreateAsyncScope();
+        }
+        catch (ObjectDisposedException)
+        {
+            return new ConnectionScope<T1, T2, T3>(true);
+        }
+
+        try
+        {
             var cn1 = scope.ServiceProvider.Resolve<T1>();
             var cn2 = scope.ServiceProvider.Resolve<T2>();
             var cn3 = scope.ServiceProvider.Resolve<T3>();
@@ -82,7 +124,13 @@ public static class ServiceProviderConnectionScopeExtensions
         }
         catch (ObjectDisposedException)
         {
+            scope.DisposeSafely();
             return new ConnectionScope<T1, T2, T3>(true);
+        }
+        catch
+        {
+            scope.DisposeSafely();
+            throw;
         }
     }
 
@@ -101,9 +149,18 @@ public static class ServiceProviderConnectionScopeExtensions
         where T3 : DataConnection
         where T4 : DataConnection
     {
+        AsyncServiceScope scope;
         try
         {
-            var scope = sp.CreateAsyncScope();
+            scope = sp.CreateAsyncScope();
+        }
+        catch (ObjectDisposedException)
+        {
+            return new ConnectionScope<T1, T2, T3, T4>(true);
+        }
+
+        try
+        {
             var cn1 = scope.ServiceProvider.Resolve<T1>();
             var cn2 = scope.ServiceProvider.Resolve<T2>();
             var cn3 = scope.ServiceProvider.Resolve<T3>();
@@ -113,7 +170,13 @@ public static class ServiceProviderConnectionScopeExtensions
         }
         catch (ObjectDisposedException)
         {
+            scope.DisposeSafely();
             return new ConnectionScope<T1, T2, T3, T4>(true);
+        }
+        catch
+        {
+            scope.DisposeSafely();
+            throw;
         }
     }
 }

--- a/integrations/linq2db/src/Annium.linq2db.Extensions/Extensions/ServiceProviderTransactionScopeExtensions.cs
+++ b/integrations/linq2db/src/Annium.linq2db.Extensions/Extensions/ServiceProviderTransactionScopeExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Data;
 using Annium.Core.DependencyInjection;
+using Annium.linq2db.Extensions.Internal.Extensions;
 using LinqToDB.Data;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -25,9 +26,18 @@ public static class ServiceProviderTransactionScopeExtensions
     )
         where T : DataConnection
     {
+        AsyncServiceScope scope;
         try
         {
-            var scope = sp.CreateAsyncScope();
+            scope = sp.CreateAsyncScope();
+        }
+        catch (ObjectDisposedException)
+        {
+            return new TransactionScope<T>(true);
+        }
+
+        try
+        {
             var cn = scope.ServiceProvider.Resolve<T>();
             var txn = cn.BeginTransaction(isolationLevel);
 
@@ -35,7 +45,15 @@ public static class ServiceProviderTransactionScopeExtensions
         }
         catch (ObjectDisposedException)
         {
+            scope.DisposeSafely();
             return new TransactionScope<T>(true);
+        }
+        catch
+        {
+            // resolution / begin-transaction failed after the scope was created — dispose it so the
+            // scope and any already-opened connection/transaction are cleaned up, then propagate
+            scope.DisposeSafely();
+            throw;
         }
     }
 
@@ -54,9 +72,18 @@ public static class ServiceProviderTransactionScopeExtensions
         where T1 : DataConnection
         where T2 : DataConnection
     {
+        AsyncServiceScope scope;
         try
         {
-            var scope = sp.CreateAsyncScope();
+            scope = sp.CreateAsyncScope();
+        }
+        catch (ObjectDisposedException)
+        {
+            return new TransactionScope<T1, T2>(true);
+        }
+
+        try
+        {
             var cn1 = scope.ServiceProvider.Resolve<T1>();
             var txn1 = cn1.BeginTransaction(isolationLevel);
             var cn2 = scope.ServiceProvider.Resolve<T2>();
@@ -66,7 +93,13 @@ public static class ServiceProviderTransactionScopeExtensions
         }
         catch (ObjectDisposedException)
         {
+            scope.DisposeSafely();
             return new TransactionScope<T1, T2>(true);
+        }
+        catch
+        {
+            scope.DisposeSafely();
+            throw;
         }
     }
 
@@ -87,9 +120,18 @@ public static class ServiceProviderTransactionScopeExtensions
         where T2 : DataConnection
         where T3 : DataConnection
     {
+        AsyncServiceScope scope;
         try
         {
-            var scope = sp.CreateAsyncScope();
+            scope = sp.CreateAsyncScope();
+        }
+        catch (ObjectDisposedException)
+        {
+            return new TransactionScope<T1, T2, T3>(true);
+        }
+
+        try
+        {
             var cn1 = scope.ServiceProvider.Resolve<T1>();
             var txn1 = cn1.BeginTransaction(isolationLevel);
             var cn2 = scope.ServiceProvider.Resolve<T2>();
@@ -101,7 +143,13 @@ public static class ServiceProviderTransactionScopeExtensions
         }
         catch (ObjectDisposedException)
         {
+            scope.DisposeSafely();
             return new TransactionScope<T1, T2, T3>(true);
+        }
+        catch
+        {
+            scope.DisposeSafely();
+            throw;
         }
     }
 
@@ -124,9 +172,18 @@ public static class ServiceProviderTransactionScopeExtensions
         where T3 : DataConnection
         where T4 : DataConnection
     {
+        AsyncServiceScope scope;
         try
         {
-            var scope = sp.CreateAsyncScope();
+            scope = sp.CreateAsyncScope();
+        }
+        catch (ObjectDisposedException)
+        {
+            return new TransactionScope<T1, T2, T3, T4>(true);
+        }
+
+        try
+        {
             var cn1 = scope.ServiceProvider.Resolve<T1>();
             var txn1 = cn1.BeginTransaction(isolationLevel);
             var cn2 = scope.ServiceProvider.Resolve<T2>();
@@ -140,7 +197,13 @@ public static class ServiceProviderTransactionScopeExtensions
         }
         catch (ObjectDisposedException)
         {
+            scope.DisposeSafely();
             return new TransactionScope<T1, T2, T3, T4>(true);
+        }
+        catch
+        {
+            scope.DisposeSafely();
+            throw;
         }
     }
 }

--- a/integrations/linq2db/src/Annium.linq2db.Extensions/Extensions/TableSaveExtensions.cs
+++ b/integrations/linq2db/src/Annium.linq2db.Extensions/Extensions/TableSaveExtensions.cs
@@ -38,6 +38,7 @@ public static class TableSaveExtensions
     /// <param name="table">The table to update</param>
     /// <param name="value">The entity to update</param>
     /// <returns>The number of affected rows</returns>
+    /// <exception cref="System.InvalidOperationException">Thrown when the entity type has no primary-key columns configured.</exception>
     public static Task<int> UpdateAsync<T>(this ITable<T> table, T value)
         where T : notnull
     {
@@ -77,16 +78,31 @@ public static class TableSaveExtensions
     private static Expression<Func<T>> BuildInsertSetter<T>(TableMetadata table, T value)
         where T : notnull
     {
-        var bindings = table
-            .Columns.Values.Where(c => c.Association is null)
+        var bindings = BuildBindings(table, value, c => c.Association is null);
+
+        return Expression.Lambda<Func<T>>(Expression.MemberInit(Expression.New(typeof(T)), bindings));
+    }
+
+    /// <summary>
+    /// Builds the member bindings for the columns matching the given predicate, reading each column's
+    /// value from the entity.
+    /// </summary>
+    /// <typeparam name="T">The entity type.</typeparam>
+    /// <param name="table">The table metadata.</param>
+    /// <param name="value">The entity value to extract column values from.</param>
+    /// <param name="predicate">The column filter (e.g. exclude associations, or associations and primary keys).</param>
+    /// <returns>The member bindings for the selected columns.</returns>
+    private static MemberBinding[] BuildBindings<T>(TableMetadata table, T value, Func<ColumnMetadata, bool> predicate)
+        where T : notnull
+    {
+        return table
+            .Columns.Values.Where(predicate)
             .Select<ColumnMetadata, MemberBinding>(c =>
             {
                 var memberValue = c.Member.GetPropertyOrFieldValue(value);
                 return Expression.Bind(c.Member, Expression.Constant(memberValue, c.Type));
             })
             .ToArray();
-
-        return Expression.Lambda<Func<T>>(Expression.MemberInit(Expression.New(typeof(T)), bindings));
     }
 
     /// <summary>
@@ -127,14 +143,7 @@ public static class TableSaveExtensions
     private static Expression<Func<TIn, TOut>> BuildUpdateSetter<TIn, TOut>(TableMetadata table, TIn value)
         where TIn : notnull
     {
-        var bindings = table
-            .Columns.Values.Where(c => c.Association is null && !c.Attribute.IsPrimaryKey)
-            .Select<ColumnMetadata, MemberBinding>(c =>
-            {
-                var memberValue = c.Member.GetPropertyOrFieldValue(value);
-                return Expression.Bind(c.Member, Expression.Constant(memberValue, c.Type));
-            })
-            .ToArray();
+        var bindings = BuildBindings(table, value, c => c.Association is null && c.PrimaryKey is null);
 
         return Expression.Lambda<Func<TIn, TOut>>(
             Expression.MemberInit(Expression.New(typeof(TIn)), bindings),

--- a/integrations/linq2db/src/Annium.linq2db.Extensions/Internal/Extensions/AsyncServiceScopeExtensions.cs
+++ b/integrations/linq2db/src/Annium.linq2db.Extensions/Internal/Extensions/AsyncServiceScopeExtensions.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Annium.linq2db.Extensions.Internal.Extensions;
+
+/// <summary>
+/// Extension helpers for cleaning up an <see cref="AsyncServiceScope"/> on a failure path.
+/// </summary>
+internal static class AsyncServiceScopeExtensions
+{
+    /// <summary>
+    /// Disposes the scope without letting a cleanup failure mask the in-flight exception. A rollback
+    /// error while disposing an already-broken connection must not replace the primary exception that
+    /// triggered the cleanup, and there is no log sink available on this static path.
+    /// </summary>
+    /// <param name="scope">The scope to dispose.</param>
+    public static void DisposeSafely(this AsyncServiceScope scope)
+    {
+        try
+        {
+            scope.Dispose();
+        }
+        catch
+        {
+            // intentionally suppressed — preserve the primary exception that triggered cleanup
+        }
+    }
+}

--- a/integrations/linq2db/src/Annium.linq2db.Extensions/Internal/Extensions/ColumnDescriptorsExtensions.cs
+++ b/integrations/linq2db/src/Annium.linq2db.Extensions/Internal/Extensions/ColumnDescriptorsExtensions.cs
@@ -9,17 +9,6 @@ namespace Annium.linq2db.Extensions.Internal.Extensions;
 internal static class ColumnDescriptorsExtensions
 {
     /// <summary>
-    /// Finds a column descriptor by name that doesn't have skip values configured.
-    /// </summary>
-    /// <param name="columns">The collection of column descriptors.</param>
-    /// <param name="name">The column name to find.</param>
-    /// <returns>The matching column descriptor (throws if not found).</returns>
-    public static ColumnDescriptor FindColumn(this IEnumerable<ColumnDescriptor> columns, string name)
-    {
-        return columns.TryFindColumn(name).NotNull();
-    }
-
-    /// <summary>
     /// Tries to finds a column descriptor by name that doesn't have skip values configured.
     /// </summary>
     /// <param name="columns">The collection of column descriptors.</param>

--- a/integrations/linq2db/src/Annium.linq2db.Extensions/Internal/Extensions/SqlInsertClauseExtensions.cs
+++ b/integrations/linq2db/src/Annium.linq2db.Extensions/Internal/Extensions/SqlInsertClauseExtensions.cs
@@ -13,7 +13,7 @@ internal static class SqlInsertClauseExtensions
     /// </summary>
     /// <param name="clause">The SQL insert clause.</param>
     /// <param name="desc">The column descriptor.</param>
-    /// <param name="value">The current time instant.</param>
+    /// <param name="value">The value to set the column to.</param>
     public static void SetValue<T>(this SqlInsertClause clause, ColumnDescriptor desc, T value)
     {
         var field = clause.Into.NotNull().FindFieldByMemberName(desc.MemberName).NotNull();

--- a/integrations/linq2db/src/Annium.linq2db.Extensions/Internal/Extensions/SqlSetExpressionsExtensions.cs
+++ b/integrations/linq2db/src/Annium.linq2db.Extensions/Internal/Extensions/SqlSetExpressionsExtensions.cs
@@ -17,7 +17,7 @@ internal static class SqlSetExpressionsExtensions
     public static SqlSetExpression? FindField(this IEnumerable<SqlSetExpression> expressions, SqlField field)
     {
         foreach (var expression in expressions)
-            if (expression.Column is SqlField f && f != null! && f.PhysicalName == field.PhysicalName)
+            if (expression.Column is SqlField f && f.PhysicalName == field.PhysicalName)
                 return expression;
 
         return null;

--- a/integrations/linq2db/src/Annium.linq2db.Extensions/Internal/Extensions/SqlUpdateClauseExtensions.cs
+++ b/integrations/linq2db/src/Annium.linq2db.Extensions/Internal/Extensions/SqlUpdateClauseExtensions.cs
@@ -11,9 +11,9 @@ internal static class SqlUpdateClauseExtensions
     /// <summary>
     /// Updates clause to set specified column to given value.
     /// </summary>
-    /// <param name="clause">The SQL insert clause.</param>
+    /// <param name="clause">The SQL update clause.</param>
     /// <param name="desc">The column descriptor.</param>
-    /// <param name="value">The current time instant.</param>
+    /// <param name="value">The value to set the column to.</param>
     public static void SetValue<T>(this SqlUpdateClause clause, ColumnDescriptor desc, T value)
     {
         var field = clause.Table.NotNull().FindFieldByMemberName(desc.MemberName).NotNull();
@@ -28,7 +28,7 @@ internal static class SqlUpdateClauseExtensions
     /// <summary>
     /// Updates clause to ignore specified column.
     /// </summary>
-    /// <param name="clause">The SQL insert clause.</param>
+    /// <param name="clause">The SQL update clause.</param>
     /// <param name="desc">The column descriptor.</param>
     public static void IgnoreValue(this SqlUpdateClause clause, ColumnDescriptor desc)
     {

--- a/integrations/linq2db/src/Annium.linq2db.Extensions/Models/ConnectionScope.T1.cs
+++ b/integrations/linq2db/src/Annium.linq2db.Extensions/Models/ConnectionScope.T1.cs
@@ -69,7 +69,8 @@ public readonly struct ConnectionScope<T> : IAsyncDisposable
 
     /// <summary>
     /// Asynchronously disposes the managed connection and service scope.
-    /// Safe to call multiple times - subsequent calls are ignored.
+    /// Disposing a disposed-state scope (returned by the factory when the provider was already
+    /// disposed) is a no-op; a live scope is expected to be disposed exactly once (via <c>await using</c>).
     /// </summary>
     /// <returns>A ValueTask representing the asynchronous dispose operation</returns>
     public async ValueTask DisposeAsync()
@@ -77,7 +78,15 @@ public readonly struct ConnectionScope<T> : IAsyncDisposable
         if (IsDisposed)
             return;
 
-        await Cn.DisposeAsync();
-        await _scope.DisposeAsync();
+        try
+        {
+            await Cn.DisposeAsync();
+        }
+        finally
+        {
+            // always dispose the scope even if the connection disposal above threw, so the scope
+            // and its pooled connection cannot leak
+            await _scope.DisposeAsync();
+        }
     }
 }

--- a/integrations/linq2db/src/Annium.linq2db.Extensions/Models/ConnectionScope.T2.cs
+++ b/integrations/linq2db/src/Annium.linq2db.Extensions/Models/ConnectionScope.T2.cs
@@ -91,7 +91,8 @@ public readonly struct ConnectionScope<T1, T2> : IAsyncDisposable
 
     /// <summary>
     /// Asynchronously disposes both managed connections and the service scope.
-    /// Safe to call multiple times - subsequent calls are ignored.
+    /// Disposing a disposed-state scope (returned by the factory when the provider was already
+    /// disposed) is a no-op; a live scope is expected to be disposed exactly once (via <c>await using</c>).
     /// </summary>
     /// <returns>A ValueTask representing the asynchronous dispose operation</returns>
     public async ValueTask DisposeAsync()
@@ -99,8 +100,17 @@ public readonly struct ConnectionScope<T1, T2> : IAsyncDisposable
         if (IsDisposed)
             return;
 
-        await Cn1.DisposeAsync();
-        await Cn2.DisposeAsync();
-        await _scope.DisposeAsync();
+        try
+        {
+            await Cn1.DisposeAsync();
+            await Cn2.DisposeAsync();
+        }
+        finally
+        {
+            // always dispose the scope even if a connection disposal above threw, so the scope
+            // and its pooled connections cannot leak (disposing the scope also disposes the
+            // scoped connections)
+            await _scope.DisposeAsync();
+        }
     }
 }

--- a/integrations/linq2db/src/Annium.linq2db.Extensions/Models/ConnectionScope.T3.cs
+++ b/integrations/linq2db/src/Annium.linq2db.Extensions/Models/ConnectionScope.T3.cs
@@ -102,7 +102,8 @@ public readonly struct ConnectionScope<T1, T2, T3> : IAsyncDisposable
 
     /// <summary>
     /// Asynchronously disposes all managed connections and the service scope.
-    /// Safe to call multiple times - subsequent calls are ignored.
+    /// Disposing a disposed-state scope (returned by the factory when the provider was already
+    /// disposed) is a no-op; a live scope is expected to be disposed exactly once (via <c>await using</c>).
     /// </summary>
     /// <returns>A ValueTask representing the asynchronous dispose operation</returns>
     public async ValueTask DisposeAsync()
@@ -110,9 +111,18 @@ public readonly struct ConnectionScope<T1, T2, T3> : IAsyncDisposable
         if (IsDisposed)
             return;
 
-        await Cn1.DisposeAsync();
-        await Cn2.DisposeAsync();
-        await Cn3.DisposeAsync();
-        await _scope.DisposeAsync();
+        try
+        {
+            await Cn1.DisposeAsync();
+            await Cn2.DisposeAsync();
+            await Cn3.DisposeAsync();
+        }
+        finally
+        {
+            // always dispose the scope even if a connection disposal above threw, so the scope
+            // and its pooled connections cannot leak (disposing the scope also disposes the
+            // scoped connections)
+            await _scope.DisposeAsync();
+        }
     }
 }

--- a/integrations/linq2db/src/Annium.linq2db.Extensions/Models/ConnectionScope.T4.cs
+++ b/integrations/linq2db/src/Annium.linq2db.Extensions/Models/ConnectionScope.T4.cs
@@ -113,7 +113,8 @@ public readonly struct ConnectionScope<T1, T2, T3, T4> : IAsyncDisposable
 
     /// <summary>
     /// Asynchronously disposes all managed connections and the service scope.
-    /// Safe to call multiple times - subsequent calls are ignored.
+    /// Disposing a disposed-state scope (returned by the factory when the provider was already
+    /// disposed) is a no-op; a live scope is expected to be disposed exactly once (via <c>await using</c>).
     /// </summary>
     /// <returns>A ValueTask representing the asynchronous dispose operation</returns>
     public async ValueTask DisposeAsync()
@@ -121,10 +122,19 @@ public readonly struct ConnectionScope<T1, T2, T3, T4> : IAsyncDisposable
         if (IsDisposed)
             return;
 
-        await Cn1.DisposeAsync();
-        await Cn2.DisposeAsync();
-        await Cn3.DisposeAsync();
-        await Cn4.DisposeAsync();
-        await _scope.DisposeAsync();
+        try
+        {
+            await Cn1.DisposeAsync();
+            await Cn2.DisposeAsync();
+            await Cn3.DisposeAsync();
+            await Cn4.DisposeAsync();
+        }
+        finally
+        {
+            // always dispose the scope even if a connection disposal above threw, so the scope
+            // and its pooled connections cannot leak (disposing the scope also disposes the
+            // scoped connections)
+            await _scope.DisposeAsync();
+        }
     }
 }

--- a/integrations/linq2db/src/Annium.linq2db.Extensions/Models/TransactionScope.T1.cs
+++ b/integrations/linq2db/src/Annium.linq2db.Extensions/Models/TransactionScope.T1.cs
@@ -91,7 +91,8 @@ public readonly struct TransactionScope<T> : IAsyncDisposable
     /// <summary>
     /// Asynchronously disposes the managed transaction and connection with automatic rollback.
     /// The transaction is rolled back before disposing the connection and service scope.
-    /// Safe to call multiple times - subsequent calls are ignored.
+    /// Disposing a disposed-state scope (returned by the factory when the provider was already
+    /// disposed) is a no-op; a live scope is expected to be disposed exactly once (via <c>await using</c>).
     /// </summary>
     /// <returns>A ValueTask representing the asynchronous dispose operation</returns>
     public async ValueTask DisposeAsync()
@@ -99,11 +100,17 @@ public readonly struct TransactionScope<T> : IAsyncDisposable
         if (IsDisposed)
             return;
 
-        // cn
-        await Txn.RollbackAsync(); // relies on linq2db internal transaction nullifying on commit
-        await Cn.DisposeAsync();
-
-        // scope
-        await _scope.DisposeAsync();
+        try
+        {
+            // cn
+            await Txn.RollbackAsync(); // relies on linq2db internal transaction nullifying on commit
+            await Cn.DisposeAsync();
+        }
+        finally
+        {
+            // always dispose the scope (which disposes the scoped connection, cascading a rollback)
+            // even if the explicit rollback/dispose above threw, so nothing leaks
+            await _scope.DisposeAsync();
+        }
     }
 }

--- a/integrations/linq2db/src/Annium.linq2db.Extensions/Models/TransactionScope.T2.cs
+++ b/integrations/linq2db/src/Annium.linq2db.Extensions/Models/TransactionScope.T2.cs
@@ -111,7 +111,8 @@ public readonly struct TransactionScope<T1, T2> : IAsyncDisposable
     /// <summary>
     /// Asynchronously disposes both managed transactions and connections with automatic rollback.
     /// All transactions are rolled back before disposing their connections and the service scope.
-    /// Safe to call multiple times - subsequent calls are ignored.
+    /// Disposing a disposed-state scope (returned by the factory when the provider was already
+    /// disposed) is a no-op; a live scope is expected to be disposed exactly once (via <c>await using</c>).
     /// </summary>
     /// <returns>A ValueTask representing the asynchronous dispose operation</returns>
     public async ValueTask DisposeAsync()
@@ -119,15 +120,21 @@ public readonly struct TransactionScope<T1, T2> : IAsyncDisposable
         if (IsDisposed)
             return;
 
-        // cn 1
-        await Txn1.RollbackAsync(); // relies on linq2db internal transaction nullifying on commit
-        await Cn1.DisposeAsync();
+        try
+        {
+            // cn 1
+            await Txn1.RollbackAsync(); // relies on linq2db internal transaction nullifying on commit
+            await Cn1.DisposeAsync();
 
-        // cn 2
-        await Txn2.RollbackAsync(); // relies on linq2db internal transaction nullifying on commit
-        await Cn2.DisposeAsync();
-
-        // scope
-        await _scope.DisposeAsync();
+            // cn 2
+            await Txn2.RollbackAsync(); // relies on linq2db internal transaction nullifying on commit
+            await Cn2.DisposeAsync();
+        }
+        finally
+        {
+            // always dispose the scope (which disposes the scoped connections, cascading rollbacks)
+            // even if an explicit rollback/dispose above threw, so nothing leaks
+            await _scope.DisposeAsync();
+        }
     }
 }

--- a/integrations/linq2db/src/Annium.linq2db.Extensions/Models/TransactionScope.T3.cs
+++ b/integrations/linq2db/src/Annium.linq2db.Extensions/Models/TransactionScope.T3.cs
@@ -131,7 +131,8 @@ public readonly struct TransactionScope<T1, T2, T3> : IAsyncDisposable
     /// <summary>
     /// Asynchronously disposes all managed transactions and connections with automatic rollback.
     /// All transactions are rolled back before disposing their connections and the service scope.
-    /// Safe to call multiple times - subsequent calls are ignored.
+    /// Disposing a disposed-state scope (returned by the factory when the provider was already
+    /// disposed) is a no-op; a live scope is expected to be disposed exactly once (via <c>await using</c>).
     /// </summary>
     /// <returns>A ValueTask representing the asynchronous dispose operation</returns>
     public async ValueTask DisposeAsync()
@@ -139,19 +140,25 @@ public readonly struct TransactionScope<T1, T2, T3> : IAsyncDisposable
         if (IsDisposed)
             return;
 
-        // cn 1
-        await Txn1.RollbackAsync(); // relies on linq2db internal transaction nullifying on commit
-        await Cn1.DisposeAsync();
+        try
+        {
+            // cn 1
+            await Txn1.RollbackAsync(); // relies on linq2db internal transaction nullifying on commit
+            await Cn1.DisposeAsync();
 
-        // cn 2
-        await Txn2.RollbackAsync(); // relies on linq2db internal transaction nullifying on commit
-        await Cn2.DisposeAsync();
+            // cn 2
+            await Txn2.RollbackAsync(); // relies on linq2db internal transaction nullifying on commit
+            await Cn2.DisposeAsync();
 
-        // cn 3
-        await Txn3.RollbackAsync(); // relies on linq2db internal transaction nullifying on commit
-        await Cn3.DisposeAsync();
-
-        // scope
-        await _scope.DisposeAsync();
+            // cn 3
+            await Txn3.RollbackAsync(); // relies on linq2db internal transaction nullifying on commit
+            await Cn3.DisposeAsync();
+        }
+        finally
+        {
+            // always dispose the scope (which disposes the scoped connections, cascading rollbacks)
+            // even if an explicit rollback/dispose above threw, so nothing leaks
+            await _scope.DisposeAsync();
+        }
     }
 }

--- a/integrations/linq2db/src/Annium.linq2db.Extensions/Models/TransactionScope.T4.cs
+++ b/integrations/linq2db/src/Annium.linq2db.Extensions/Models/TransactionScope.T4.cs
@@ -189,7 +189,8 @@ public readonly struct TransactionScope<T1, T2, T3, T4> : IAsyncDisposable
     /// <summary>
     /// Asynchronously disposes all managed transactions and connections with automatic rollback.
     /// All transactions are rolled back before disposing their connections and the service scope.
-    /// Safe to call multiple times - subsequent calls are ignored.
+    /// Disposing a disposed-state scope (returned by the factory when the provider was already
+    /// disposed) is a no-op; a live scope is expected to be disposed exactly once (via <c>await using</c>).
     /// </summary>
     /// <returns>A ValueTask representing the asynchronous dispose operation</returns>
     public async ValueTask DisposeAsync()
@@ -197,23 +198,29 @@ public readonly struct TransactionScope<T1, T2, T3, T4> : IAsyncDisposable
         if (IsDisposed)
             return;
 
-        // cn 1
-        await Txn1.RollbackAsync(); // relies on linq2db internal transaction nullifying on commit
-        await Cn1.DisposeAsync();
+        try
+        {
+            // cn 1
+            await Txn1.RollbackAsync(); // relies on linq2db internal transaction nullifying on commit
+            await Cn1.DisposeAsync();
 
-        // cn 2
-        await Txn2.RollbackAsync(); // relies on linq2db internal transaction nullifying on commit
-        await Cn2.DisposeAsync();
+            // cn 2
+            await Txn2.RollbackAsync(); // relies on linq2db internal transaction nullifying on commit
+            await Cn2.DisposeAsync();
 
-        // cn 3
-        await Txn3.RollbackAsync(); // relies on linq2db internal transaction nullifying on commit
-        await Cn3.DisposeAsync();
+            // cn 3
+            await Txn3.RollbackAsync(); // relies on linq2db internal transaction nullifying on commit
+            await Cn3.DisposeAsync();
 
-        // cn 4
-        await Txn4.RollbackAsync(); // relies on linq2db internal transaction nullifying on commit
-        await Cn4.DisposeAsync();
-
-        // scope
-        await _scope.DisposeAsync();
+            // cn 4
+            await Txn4.RollbackAsync(); // relies on linq2db internal transaction nullifying on commit
+            await Cn4.DisposeAsync();
+        }
+        finally
+        {
+            // always dispose the scope (which disposes the scoped connections, cascading rollbacks)
+            // even if an explicit rollback/dispose above threw, so nothing leaks
+            await _scope.DisposeAsync();
+        }
     }
 }

--- a/integrations/linq2db/src/Annium.linq2db.Extensions/ServiceContainerExtensions.cs
+++ b/integrations/linq2db/src/Annium.linq2db.Extensions/ServiceContainerExtensions.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Annium.Core.DependencyInjection;
 using Annium.Core.Runtime;
 
@@ -9,12 +10,18 @@ namespace Annium.linq2db.Extensions;
 public static class ServiceContainerExtensions
 {
     /// <summary>
-    /// Registers all entity configurations found in the application assemblies
+    /// Registers all entity configurations found in the application assemblies. The scan is global
+    /// (every <see cref="IEntityConfiguration{TEntity}"/> in loaded assemblies), so it is applied
+    /// once per container even when multiple DataConnection types each trigger it via AddPostgreSql;
+    /// subsequent calls are a no-op.
     /// </summary>
     /// <param name="container">The service container to configure</param>
     /// <returns>The configured service container for chaining</returns>
     public static IServiceContainer AddEntityConfigurations(this IServiceContainer container)
     {
+        if (container.Collection.Any(x => x.ServiceType == typeof(IEntityConfiguration)))
+            return container;
+
         container
             .AddAll()
             .Where(x => x is { IsClass: true, IsAbstract: false })

--- a/integrations/linq2db/src/Annium.linq2db.PostgreSql/ServiceContainerExtensions.cs
+++ b/integrations/linq2db/src/Annium.linq2db.PostgreSql/ServiceContainerExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Annium.Core.DependencyInjection;
 using Annium.linq2db.Extensions;
 using Annium.Logging;
@@ -178,7 +179,7 @@ file sealed record MappingSchemaContainer<TConnection>(MappingSchema Schema);
 /// </summary>
 /// <typeparam name="TConnection">The connection type</typeparam>
 // ReSharper disable once UnusedTypeParameter
-file sealed record DataSourceContainer<TConnection> : IDisposable, ILogSubject
+file sealed record DataSourceContainer<TConnection> : IDisposable, IAsyncDisposable, ILogSubject
 {
     /// <summary>
     /// Gets the Npgsql data source
@@ -208,6 +209,16 @@ file sealed record DataSourceContainer<TConnection> : IDisposable, ILogSubject
     public void Dispose()
     {
         DataSource.Dispose();
+        this.Trace("disposed");
+    }
+
+    /// <summary>
+    /// Asynchronously disposes the data source (tearing down the connection pool without blocking) and logs the disposal.
+    /// </summary>
+    /// <returns>A value task that completes when the data source has been disposed.</returns>
+    public async ValueTask DisposeAsync()
+    {
+        await DataSource.DisposeAsync();
         this.Trace("disposed");
     }
 }

--- a/integrations/linq2db/tests/Annium.linq2db.PostgreSql.Tests/Db/Migrations/004_created_only_entities.sql
+++ b/integrations/linq2db/tests/Annium.linq2db.PostgreSql.Tests/Db/Migrations/004_created_only_entities.sql
@@ -1,0 +1,6 @@
+create table created_only_entities (
+  id uuid not null,
+  content text not null,
+  created_at timestamptz not null,
+  constraint pk_created_only_entities primary key (id)
+);

--- a/integrations/linq2db/tests/Annium.linq2db.PostgreSql.Tests/Db/Migrations/005_manual_time_entities.sql
+++ b/integrations/linq2db/tests/Annium.linq2db.PostgreSql.Tests/Db/Migrations/005_manual_time_entities.sql
@@ -1,0 +1,7 @@
+create table manual_time_entities (
+  id uuid not null,
+  content text not null,
+  created_at timestamptz not null,
+  updated_at timestamptz not null,
+  constraint pk_manual_time_entities primary key (id)
+);

--- a/integrations/linq2db/tests/Annium.linq2db.PostgreSql.Tests/Extensions/TableInsertOrUpdateExtensionsTests.cs
+++ b/integrations/linq2db/tests/Annium.linq2db.PostgreSql.Tests/Extensions/TableInsertOrUpdateExtensionsTests.cs
@@ -48,4 +48,54 @@ public class TableInsertOrUpdateExtensionsTests : TableInsertOrUpdateExtensionsT
     {
         await InsertOrUpdate_Base();
     }
+
+    /// <summary>
+    /// Tests created-only insert timestamp handling using PostgreSQL backend
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation</returns>
+    [Fact]
+    public async Task Insert_CreatedOnly()
+    {
+        await Insert_CreatedOnly_Base();
+    }
+
+    /// <summary>
+    /// Tests created-only upsert timestamp handling using PostgreSQL backend
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation</returns>
+    [Fact]
+    public async Task InsertOrUpdate_CreatedOnly()
+    {
+        await InsertOrUpdate_CreatedOnly_Base();
+    }
+
+    /// <summary>
+    /// Tests manual-timestamp insert/update through the auto pipeline using PostgreSQL backend
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation</returns>
+    [Fact]
+    public async Task Insert_ManualTime()
+    {
+        await Insert_ManualTime_Base();
+    }
+
+    /// <summary>
+    /// Tests composite-primary-key update targeting using PostgreSQL backend
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation</returns>
+    [Fact]
+    public async Task Update_CompositeKey()
+    {
+        await Update_CompositeKey_Base();
+    }
+
+    /// <summary>
+    /// Tests that updating a table with no primary key throws using PostgreSQL backend
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation</returns>
+    [Fact]
+    public async Task Update_NoPrimaryKey_Throws()
+    {
+        await Update_NoPrimaryKey_Throws_Base();
+    }
 }

--- a/integrations/linq2db/tests/Annium.linq2db.PostgreSql.Tests/Models/ScopeTests.cs
+++ b/integrations/linq2db/tests/Annium.linq2db.PostgreSql.Tests/Models/ScopeTests.cs
@@ -1,0 +1,130 @@
+using System.Threading.Tasks;
+using Annium.linq2db.Tests.Lib.Models;
+using Xunit;
+
+namespace Annium.linq2db.PostgreSql.Tests.Models;
+
+/// <summary>
+/// Tests for connection/transaction scope structs and their service-provider factory extensions
+/// against the PostgreSQL backend.
+/// </summary>
+public class ScopeTests : ScopeTestsBase
+{
+    /// <summary>
+    /// Initializes a new instance of the ScopeTests class
+    /// </summary>
+    /// <param name="outputHelper">Test output helper for logging</param>
+    public ScopeTests(ITestOutputHelper outputHelper)
+        : base(outputHelper)
+    {
+        RegisterServicePack<ServicePack>();
+    }
+
+    /// <summary>
+    /// Tests that a transaction scope rolls back on dispose using PostgreSQL backend
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation</returns>
+    [Fact]
+    public async Task TransactionScope_RollsBackOnDispose()
+    {
+        await TransactionScope_RollsBackOnDispose_Base();
+    }
+
+    /// <summary>
+    /// Tests that disposing a disposed-state transaction scope is a no-op using PostgreSQL backend
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation</returns>
+    [Fact]
+    public async Task TransactionScope_DisposedState_DisposeIsNoop()
+    {
+        await TransactionScope_DisposedState_DisposeIsNoop_Base();
+    }
+
+    /// <summary>
+    /// Tests that disposed-state transaction scopes guard their accessors
+    /// </summary>
+    [Fact]
+    public void TransactionScope_DisposedState_Throws()
+    {
+        TransactionScope_DisposedState_Throws_Base();
+    }
+
+    /// <summary>
+    /// Tests that disposed-state connection scopes guard their accessors
+    /// </summary>
+    [Fact]
+    public void ConnectionScope_DisposedState_Throws()
+    {
+        ConnectionScope_DisposedState_Throws_Base();
+    }
+
+    /// <summary>
+    /// Tests that disposing a disposed-state connection scope is a no-op using PostgreSQL backend
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation</returns>
+    [Fact]
+    public async Task ConnectionScope_DisposedState_DisposeIsNoop()
+    {
+        await ConnectionScope_DisposedState_DisposeIsNoop_Base();
+    }
+
+    /// <summary>
+    /// Tests that a connection scope from a disposed provider is itself disposed using PostgreSQL backend
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation</returns>
+    [Fact]
+    public async Task GetConnectionScope_DisposedProvider_ReturnsDisposedScope()
+    {
+        await GetConnectionScope_DisposedProvider_ReturnsDisposedScope_Base();
+    }
+
+    /// <summary>
+    /// Tests that a transaction scope from a disposed provider is itself disposed using PostgreSQL backend
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation</returns>
+    [Fact]
+    public async Task GetTransactionScope_DisposedProvider_ReturnsDisposedScope()
+    {
+        await GetTransactionScope_DisposedProvider_ReturnsDisposedScope_Base();
+    }
+
+    /// <summary>
+    /// Tests the multi-arity connection scope overloads against the PostgreSQL backend
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation</returns>
+    [Fact]
+    public async Task ConnectionScope_MultiArity_Live()
+    {
+        await ConnectionScope_MultiArity_Live_Base();
+    }
+
+    /// <summary>
+    /// Tests 2-arity transaction rollback on dispose against the PostgreSQL backend
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation</returns>
+    [Fact]
+    public async Task TransactionScope_TwoArity_RollsBackOnDispose()
+    {
+        await TransactionScope_TwoArity_RollsBackOnDispose_Base();
+    }
+
+    /// <summary>
+    /// Tests 3-arity transaction rollback on dispose against the PostgreSQL backend
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation</returns>
+    [Fact]
+    public async Task TransactionScope_ThreeArity_RollsBackOnDispose()
+    {
+        await TransactionScope_ThreeArity_RollsBackOnDispose_Base();
+    }
+
+    /// <summary>
+    /// Tests 4-arity transaction rollback on dispose against the PostgreSQL backend
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation</returns>
+    [Fact]
+    public async Task TransactionScope_MultiArity_RollsBackOnDispose()
+    {
+        await TransactionScope_MultiArity_RollsBackOnDispose_Base();
+    }
+}

--- a/integrations/linq2db/tests/Annium.linq2db.PostgreSql.Tests/ServicePack.cs
+++ b/integrations/linq2db/tests/Annium.linq2db.PostgreSql.Tests/ServicePack.cs
@@ -22,6 +22,9 @@ internal class ServicePack : ServicePackBase
     public override Task RegisterAsync(IServiceContainer container, IServiceProvider provider, CancellationToken ct)
     {
         container.AddPostgreSql<Connection>();
+        container.AddPostgreSql<ConnectionB>();
+        container.AddPostgreSql<ConnectionC>();
+        container.AddPostgreSql<ConnectionD>();
         container.Add<Database>().AsSelf().Singleton();
         container.Add(sp => sp.Resolve<Database>().Config).AsSelf().Singleton();
         return Task.CompletedTask;

--- a/integrations/linq2db/tests/Annium.linq2db.Tests.Lib/Configuration/ConfigurationTestsBase.cs
+++ b/integrations/linq2db/tests/Annium.linq2db.Tests.Lib/Configuration/ConfigurationTestsBase.cs
@@ -1,5 +1,7 @@
+using System.Linq;
 using Annium.linq2db.Extensions;
 using Annium.linq2db.Tests.Lib.Db;
+using Annium.linq2db.Tests.Lib.Db.Models;
 using Annium.Testing;
 using Xunit;
 
@@ -29,7 +31,22 @@ public class ConfigurationTestsBase : TestBase
         using var conn = Get<Connection>();
         var databaseMetadata = conn.MappingSchema.Describe();
 
-        // assert
-        databaseMetadata.Tables.Has(3);
+        // assert — three core tables plus the no-primary-key fixture (Update_NoPrimaryKey_Throws),
+        // the created-only fixture (Insert_CreatedOnly), and the manual-timestamp fixture
+        // (Insert_ManualTime); assert identity and key structure, not just the count
+        databaseMetadata.Tables.Has(6);
+
+        var companies = databaseMetadata.Tables[typeof(Company)];
+        companies.Name.Is("companies");
+        companies.Columns.Values.Count(c => c.PrimaryKey is not null).Is(1);
+
+        var employees = databaseMetadata.Tables[typeof(Employee)];
+        employees.Name.Is("employees");
+        employees.Columns.Values.Count(c => c.PrimaryKey is not null).Is(1);
+
+        // CompanyEmployee has a composite primary key (CompanyId + EmployeeId)
+        var companyEmployees = databaseMetadata.Tables[typeof(CompanyEmployee)];
+        companyEmployees.Name.Is("company_employees");
+        companyEmployees.Columns.Values.Count(c => c.PrimaryKey is not null).Is(2);
     }
 }

--- a/integrations/linq2db/tests/Annium.linq2db.Tests.Lib/Db/Configurations/CompanyConfiguration.cs
+++ b/integrations/linq2db/tests/Annium.linq2db.Tests.Lib/Db/Configurations/CompanyConfiguration.cs
@@ -22,8 +22,6 @@ internal class CompanyConfiguration
         this.ConfigureId(builder);
         this.ConfigureAutoCreatedUpdatedTime(builder);
         builder.HasTableName("companies");
-        builder.HasPrimaryKey(x => x.Id);
-        builder.Property(x => x.Id).IsColumn();
         builder.Property(x => x.Name).IsColumn();
         builder.Property(x => x.Metadata).IsColumn().HasDbType("jsonb").HasDataType(DataType.Json);
         builder.Association(x => x.Employees, x => x.Id, x => x.CompanyId, false);

--- a/integrations/linq2db/tests/Annium.linq2db.Tests.Lib/Db/Configurations/CreatedOnlyEntityConfiguration.cs
+++ b/integrations/linq2db/tests/Annium.linq2db.Tests.Lib/Db/Configurations/CreatedOnlyEntityConfiguration.cs
@@ -1,0 +1,27 @@
+using System;
+using Annium.linq2db.Extensions;
+using Annium.linq2db.Tests.Lib.Db.Models;
+using LinqToDB.Mapping;
+
+namespace Annium.linq2db.Tests.Lib.Db.Configurations;
+
+/// <summary>
+/// linq2db entity configuration for <see cref="CreatedOnlyEntity"/> — an ID entity with auto-managed
+/// created-only timestamp tracking (no updated timestamp), configured via <c>ConfigureAutoCreatedTime</c>.
+/// </summary>
+internal class CreatedOnlyEntityConfiguration
+    : IIdEntityConfiguration<CreatedOnlyEntity, Guid>,
+        ICreatedTimeEntityConfiguration<CreatedOnlyEntity>
+{
+    /// <summary>
+    /// Configures the CreatedOnlyEntity mapping including table name, primary key, content column, and created-only timestamp.
+    /// </summary>
+    /// <param name="builder">Entity mapping builder for CreatedOnlyEntity.</param>
+    public void Configure(EntityMappingBuilder<CreatedOnlyEntity> builder)
+    {
+        this.ConfigureId(builder);
+        this.ConfigureAutoCreatedTime(builder);
+        builder.HasTableName("created_only_entities");
+        builder.Property(x => x.Content).IsColumn();
+    }
+}

--- a/integrations/linq2db/tests/Annium.linq2db.Tests.Lib/Db/Configurations/EmployeeConfiguration.cs
+++ b/integrations/linq2db/tests/Annium.linq2db.Tests.Lib/Db/Configurations/EmployeeConfiguration.cs
@@ -21,8 +21,6 @@ internal class EmployeeConfiguration
         this.ConfigureId(builder);
         this.ConfigureAutoCreatedUpdatedTime(builder);
         builder.HasTableName("employees");
-        builder.HasPrimaryKey(x => x.Id);
-        builder.Property(x => x.Id).IsColumn();
         builder.Property(x => x.Name).IsColumn();
         builder.Association(x => x.Chief, x => x.ChiefId, x => x!.Id);
         builder.Association(x => x.Subordinates, x => x.Id, x => x.ChiefId);

--- a/integrations/linq2db/tests/Annium.linq2db.Tests.Lib/Db/Configurations/ManualTimeEntityConfiguration.cs
+++ b/integrations/linq2db/tests/Annium.linq2db.Tests.Lib/Db/Configurations/ManualTimeEntityConfiguration.cs
@@ -1,0 +1,28 @@
+using System;
+using Annium.linq2db.Extensions;
+using Annium.linq2db.Tests.Lib.Db.Models;
+using LinqToDB.Mapping;
+
+namespace Annium.linq2db.Tests.Lib.Db.Configurations;
+
+/// <summary>
+/// linq2db entity configuration for <see cref="ManualTimeEntity"/> — an ID entity whose created/updated
+/// timestamps are application-managed (configured via <c>ConfigureManualCreatedUpdatedTime</c>, which marks
+/// the timestamp columns to be skipped by the auto-timestamp pipeline).
+/// </summary>
+internal class ManualTimeEntityConfiguration
+    : IIdEntityConfiguration<ManualTimeEntity, Guid>,
+        ICreatedUpdatedTimeEntityConfiguration<ManualTimeEntity>
+{
+    /// <summary>
+    /// Configures the ManualTimeEntity mapping including table name, primary key, content column, and manual timestamps.
+    /// </summary>
+    /// <param name="builder">Entity mapping builder for ManualTimeEntity.</param>
+    public void Configure(EntityMappingBuilder<ManualTimeEntity> builder)
+    {
+        this.ConfigureId(builder);
+        this.ConfigureManualCreatedUpdatedTime(builder);
+        builder.HasTableName("manual_time_entities");
+        builder.Property(x => x.Content).IsColumn();
+    }
+}

--- a/integrations/linq2db/tests/Annium.linq2db.Tests.Lib/Db/Configurations/NoPkEntityConfiguration.cs
+++ b/integrations/linq2db/tests/Annium.linq2db.Tests.Lib/Db/Configurations/NoPkEntityConfiguration.cs
@@ -1,0 +1,22 @@
+using Annium.linq2db.Extensions;
+using Annium.linq2db.Tests.Lib.Db.Models;
+using LinqToDB.Mapping;
+
+namespace Annium.linq2db.Tests.Lib.Db.Configurations;
+
+/// <summary>
+/// linq2db entity configuration for <see cref="NoPkEntity"/> — a table mapping with no primary key,
+/// used to exercise the empty-primary-key edge of the update predicate builder.
+/// </summary>
+internal class NoPkEntityConfiguration : IEntityConfiguration<NoPkEntity>
+{
+    /// <summary>
+    /// Configures the NoPkEntity mapping with a table name and a single column, deliberately without a primary key.
+    /// </summary>
+    /// <param name="builder">Entity mapping builder for NoPkEntity.</param>
+    public void Configure(EntityMappingBuilder<NoPkEntity> builder)
+    {
+        builder.HasTableName("no_pk_entities");
+        builder.Property(x => x.Value).IsColumn();
+    }
+}

--- a/integrations/linq2db/tests/Annium.linq2db.Tests.Lib/Db/ConnectionB.cs
+++ b/integrations/linq2db/tests/Annium.linq2db.Tests.Lib/Db/ConnectionB.cs
@@ -1,0 +1,41 @@
+using Annium.linq2db.Extensions;
+using LinqToDB;
+using LinqToDB.Data;
+using LinqToDB.Internal.SqlQuery;
+
+namespace Annium.linq2db.Tests.Lib.Db;
+
+/// <summary>
+/// A second distinct DataConnection type used to exercise the multi-arity connection/transaction
+/// scope overloads (which are generic over distinct connection types). Points at the same test
+/// database as <see cref="Connection"/> but is a separate connection/transaction.
+/// </summary>
+public sealed class ConnectionB : DataConnection
+{
+    /// <summary>
+    /// Time provider for timestamp management.
+    /// </summary>
+    private readonly ITimeProvider _timeProvider;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConnectionB"/> class.
+    /// </summary>
+    /// <param name="timeProvider">Time provider for timestamp operations.</param>
+    /// <param name="config">Database connection configuration.</param>
+    public ConnectionB(ITimeProvider timeProvider, DataOptions<ConnectionB> config)
+        : base(config.Options)
+    {
+        _timeProvider = timeProvider;
+    }
+
+    /// <summary>
+    /// Processes SQL queries to handle created/updated timestamp logic.
+    /// </summary>
+    /// <param name="statement">SQL statement to process.</param>
+    /// <param name="context">Query evaluation context.</param>
+    /// <returns>Processed SQL statement with timestamp handling.</returns>
+    protected override SqlStatement ProcessQuery(SqlStatement statement, EvaluationContext context)
+    {
+        return this.ProcessCreatedUpdatedTimeQuery(statement, _timeProvider);
+    }
+}

--- a/integrations/linq2db/tests/Annium.linq2db.Tests.Lib/Db/ConnectionC.cs
+++ b/integrations/linq2db/tests/Annium.linq2db.Tests.Lib/Db/ConnectionC.cs
@@ -1,0 +1,41 @@
+using Annium.linq2db.Extensions;
+using LinqToDB;
+using LinqToDB.Data;
+using LinqToDB.Internal.SqlQuery;
+
+namespace Annium.linq2db.Tests.Lib.Db;
+
+/// <summary>
+/// A third distinct DataConnection type used to exercise the 3- and 4-arity connection/transaction
+/// scope overloads. Points at the same test database as <see cref="Connection"/> but is a separate
+/// connection/transaction.
+/// </summary>
+public sealed class ConnectionC : DataConnection
+{
+    /// <summary>
+    /// Time provider for timestamp management.
+    /// </summary>
+    private readonly ITimeProvider _timeProvider;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConnectionC"/> class.
+    /// </summary>
+    /// <param name="timeProvider">Time provider for timestamp operations.</param>
+    /// <param name="config">Database connection configuration.</param>
+    public ConnectionC(ITimeProvider timeProvider, DataOptions<ConnectionC> config)
+        : base(config.Options)
+    {
+        _timeProvider = timeProvider;
+    }
+
+    /// <summary>
+    /// Processes SQL queries to handle created/updated timestamp logic.
+    /// </summary>
+    /// <param name="statement">SQL statement to process.</param>
+    /// <param name="context">Query evaluation context.</param>
+    /// <returns>Processed SQL statement with timestamp handling.</returns>
+    protected override SqlStatement ProcessQuery(SqlStatement statement, EvaluationContext context)
+    {
+        return this.ProcessCreatedUpdatedTimeQuery(statement, _timeProvider);
+    }
+}

--- a/integrations/linq2db/tests/Annium.linq2db.Tests.Lib/Db/ConnectionD.cs
+++ b/integrations/linq2db/tests/Annium.linq2db.Tests.Lib/Db/ConnectionD.cs
@@ -1,0 +1,41 @@
+using Annium.linq2db.Extensions;
+using LinqToDB;
+using LinqToDB.Data;
+using LinqToDB.Internal.SqlQuery;
+
+namespace Annium.linq2db.Tests.Lib.Db;
+
+/// <summary>
+/// A fourth distinct DataConnection type used to exercise the 4-arity connection/transaction scope
+/// overloads. Points at the same test database as <see cref="Connection"/> but is a separate
+/// connection/transaction.
+/// </summary>
+public sealed class ConnectionD : DataConnection
+{
+    /// <summary>
+    /// Time provider for timestamp management.
+    /// </summary>
+    private readonly ITimeProvider _timeProvider;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConnectionD"/> class.
+    /// </summary>
+    /// <param name="timeProvider">Time provider for timestamp operations.</param>
+    /// <param name="config">Database connection configuration.</param>
+    public ConnectionD(ITimeProvider timeProvider, DataOptions<ConnectionD> config)
+        : base(config.Options)
+    {
+        _timeProvider = timeProvider;
+    }
+
+    /// <summary>
+    /// Processes SQL queries to handle created/updated timestamp logic.
+    /// </summary>
+    /// <param name="statement">SQL statement to process.</param>
+    /// <param name="context">Query evaluation context.</param>
+    /// <returns>Processed SQL statement with timestamp handling.</returns>
+    protected override SqlStatement ProcessQuery(SqlStatement statement, EvaluationContext context)
+    {
+        return this.ProcessCreatedUpdatedTimeQuery(statement, _timeProvider);
+    }
+}

--- a/integrations/linq2db/tests/Annium.linq2db.Tests.Lib/Db/Models/CreatedOnlyEntity.cs
+++ b/integrations/linq2db/tests/Annium.linq2db.Tests.Lib/Db/Models/CreatedOnlyEntity.cs
@@ -1,0 +1,49 @@
+using System;
+using Annium.Data.Models;
+using NodaTime;
+
+namespace Annium.linq2db.Tests.Lib.Db.Models;
+
+/// <summary>
+/// An entity that tracks a created timestamp but no updated timestamp (implements
+/// <see cref="ICreatedTimeEntity"/> but not <see cref="ICreatedUpdatedTimeEntity"/>), used to
+/// exercise the created-only branch of the auto-timestamp query processing and the public
+/// <c>ConfigureAutoCreatedTime</c> configuration API.
+/// </summary>
+public sealed record CreatedOnlyEntity : IIdEntity<Guid>, ICreatedTimeEntity
+{
+    /// <summary>
+    /// Gets the unique identifier for the entity.
+    /// </summary>
+    public Guid Id { get; private init; } = Guid.NewGuid();
+
+    /// <summary>
+    /// Gets or sets the entity's content.
+    /// </summary>
+    public string Content { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Gets the timestamp when the entity was created.
+    /// </summary>
+    public Instant CreatedAt { get; private set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CreatedOnlyEntity"/> record.
+    /// </summary>
+    /// <param name="content">The content to store.</param>
+    public CreatedOnlyEntity(string content)
+    {
+        Content = content;
+    }
+
+    /// <summary>
+    /// Private constructor for ORM usage.
+    /// </summary>
+    private CreatedOnlyEntity() { }
+
+    /// <summary>
+    /// Updates the entity's content.
+    /// </summary>
+    /// <param name="content">New content to set.</param>
+    public void SetContent(string content) => Content = content;
+}

--- a/integrations/linq2db/tests/Annium.linq2db.Tests.Lib/Db/Models/ManualTimeEntity.cs
+++ b/integrations/linq2db/tests/Annium.linq2db.Tests.Lib/Db/Models/ManualTimeEntity.cs
@@ -1,0 +1,66 @@
+using System;
+using Annium.Data.Models;
+using NodaTime;
+
+namespace Annium.linq2db.Tests.Lib.Db.Models;
+
+/// <summary>
+/// An entity whose created/updated timestamps are managed by the application (configured via
+/// ConfigureManualCreatedUpdatedTime), used to exercise the manual-timestamp path through a
+/// Connection whose ProcessQuery routes into the auto-timestamp pipeline. The auto pipeline must
+/// leave the manually-managed columns untouched.
+/// </summary>
+public sealed record ManualTimeEntity : IIdEntity<Guid>, ICreatedUpdatedTimeEntity
+{
+    /// <summary>
+    /// Gets the unique identifier for the entity.
+    /// </summary>
+    public Guid Id { get; private init; } = Guid.NewGuid();
+
+    /// <summary>
+    /// Gets or sets the entity's content.
+    /// </summary>
+    public string Content { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Gets the application-managed created timestamp.
+    /// </summary>
+    public Instant CreatedAt { get; private set; }
+
+    /// <summary>
+    /// Gets the application-managed updated timestamp.
+    /// </summary>
+    public Instant UpdatedAt { get; private set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ManualTimeEntity"/> record.
+    /// </summary>
+    /// <param name="content">The content to store.</param>
+    public ManualTimeEntity(string content)
+    {
+        Content = content;
+    }
+
+    /// <summary>
+    /// Private constructor for ORM usage.
+    /// </summary>
+    private ManualTimeEntity() { }
+
+    /// <summary>
+    /// Updates the entity's content.
+    /// </summary>
+    /// <param name="content">New content to set.</param>
+    public void SetContent(string content) => Content = content;
+
+    /// <summary>
+    /// Sets the application-managed created timestamp.
+    /// </summary>
+    /// <param name="createdAt">The created timestamp.</param>
+    public void SetCreatedAt(Instant createdAt) => CreatedAt = createdAt;
+
+    /// <summary>
+    /// Sets the application-managed updated timestamp.
+    /// </summary>
+    /// <param name="updatedAt">The updated timestamp.</param>
+    public void SetUpdatedAt(Instant updatedAt) => UpdatedAt = updatedAt;
+}

--- a/integrations/linq2db/tests/Annium.linq2db.Tests.Lib/Db/Models/NoPkEntity.cs
+++ b/integrations/linq2db/tests/Annium.linq2db.Tests.Lib/Db/Models/NoPkEntity.cs
@@ -1,0 +1,29 @@
+namespace Annium.linq2db.Tests.Lib.Db.Models;
+
+/// <summary>
+/// A minimal entity with no primary key, used to exercise the empty-primary-key edge of
+/// <c>TableSaveExtensions.UpdateAsync</c> (its predicate builder aggregates over the primary-key
+/// columns and throws when there are none). Intentionally not backed by a migration — no test
+/// queries it; it exists only in the mapping schema so metadata resolution succeeds.
+/// </summary>
+public sealed record NoPkEntity
+{
+    /// <summary>
+    /// Gets the entity's single value column.
+    /// </summary>
+    public string Value { get; private init; } = string.Empty;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NoPkEntity"/> record.
+    /// </summary>
+    /// <param name="value">The value to store.</param>
+    public NoPkEntity(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// Private constructor for ORM usage.
+    /// </summary>
+    private NoPkEntity() { }
+}

--- a/integrations/linq2db/tests/Annium.linq2db.Tests.Lib/Extensions/TableInsertOrUpdateExtensionsTestsBase.cs
+++ b/integrations/linq2db/tests/Annium.linq2db.Tests.Lib/Extensions/TableInsertOrUpdateExtensionsTestsBase.cs
@@ -163,6 +163,180 @@ public class TableInsertOrUpdateExtensionsTestsBase : TestBase
     }
 
     /// <summary>
+    /// Tests that inserting a created-only entity (ICreatedTimeEntity, no UpdatedAt) auto-stamps
+    /// CreatedAt, exercising the created-only branch of the insert time-query processing.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    protected async Task Insert_CreatedOnly_Base()
+    {
+        // arrange
+        var timeManager = Get<ITimeManager>();
+        timeManager.SetNow(SystemClock.Instance.GetCurrentInstant());
+        var now = timeManager.Now;
+        await using var scope = Provider.GetConnectionScope<Connection>();
+        scope.ThrowIfDisposed();
+        var conn = scope.Cn;
+        var entity = new CreatedOnlyEntity("content");
+
+        // act
+        timeManager.AddSecond();
+        await conn.GetTable<CreatedOnlyEntity>().InsertAsync(entity);
+
+        // assert — CreatedAt auto-stamped; there is no UpdatedAt to manage
+        var loaded = await conn.GetTable<CreatedOnlyEntity>().SingleAsync(x => x.Id == entity.Id);
+        loaded.Content.Is("content");
+        loaded.CreatedAt.IsGreater(now).IsLess(now + Duration.FromSeconds(2));
+    }
+
+    /// <summary>
+    /// Tests that upserting a created-only entity stamps CreatedAt on insert and leaves it unchanged
+    /// on update, exercising the created-only branch of the insert-or-update time-query processing.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    protected async Task InsertOrUpdate_CreatedOnly_Base()
+    {
+        // arrange
+        var timeManager = Get<ITimeManager>();
+        timeManager.SetNow(SystemClock.Instance.GetCurrentInstant());
+        await using var scope = Provider.GetConnectionScope<Connection>();
+        scope.ThrowIfDisposed();
+        var conn = scope.Cn;
+        var entity = new CreatedOnlyEntity("content");
+
+        // act — insert via upsert
+        await conn.GetTable<CreatedOnlyEntity>().InsertOrUpdateAsync(entity);
+
+        // assert
+        var loaded = await conn.GetTable<CreatedOnlyEntity>().SingleAsync(x => x.Id == entity.Id);
+        loaded.Content.Is("content");
+        var createdAt = loaded.CreatedAt;
+
+        // act — update via upsert; CreatedAt is ignored on the update path, content changes
+        entity.SetContent("updated");
+        timeManager.AddSecond();
+        await conn.GetTable<CreatedOnlyEntity>().InsertOrUpdateAsync(entity);
+
+        // assert — content updated, CreatedAt unchanged
+        loaded = await conn.GetTable<CreatedOnlyEntity>().SingleAsync(x => x.Id == entity.Id);
+        loaded.Content.Is("updated");
+        loaded.CreatedAt.Is(createdAt);
+    }
+
+    /// <summary>
+    /// Tests that inserting and updating a manual-timestamp entity (ConfigureManualCreatedUpdatedTime)
+    /// through a Connection whose ProcessQuery routes into the auto-timestamp pipeline leaves the
+    /// application-supplied CreatedAt/UpdatedAt untouched (the auto pipeline must skip manual columns).
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    protected async Task Insert_ManualTime_Base()
+    {
+        // arrange
+        var timeManager = Get<ITimeManager>();
+        timeManager.SetNow(SystemClock.Instance.GetCurrentInstant());
+        await using var scope = Provider.GetConnectionScope<Connection>();
+        scope.ThrowIfDisposed();
+        var conn = scope.Cn;
+
+        var appCreated = Instant.FromUtc(2020, 1, 1, 0, 0, 0);
+        var appUpdated = Instant.FromUtc(2021, 1, 1, 0, 0, 0);
+        var entity = new ManualTimeEntity("content");
+        entity.SetCreatedAt(appCreated);
+        entity.SetUpdatedAt(appUpdated);
+
+        // act — insert through the auto-ProcessQuery Connection; the manual columns must be left alone
+        await conn.GetTable<ManualTimeEntity>().InsertAsync(entity);
+
+        // assert — application-supplied timestamps preserved, not overwritten by the auto pipeline
+        var loaded = await conn.GetTable<ManualTimeEntity>().SingleAsync(x => x.Id == entity.Id);
+        loaded.Content.Is("content");
+        loaded.CreatedAt.Is(appCreated);
+        loaded.UpdatedAt.Is(appUpdated);
+
+        // act — update through the same pipeline; manual timestamps still left to the application
+        var appUpdated2 = Instant.FromUtc(2022, 1, 1, 0, 0, 0);
+        entity.SetContent("updated");
+        entity.SetUpdatedAt(appUpdated2);
+        await conn.GetTable<ManualTimeEntity>().UpdateAsync(entity);
+
+        // assert
+        loaded = await conn.GetTable<ManualTimeEntity>().SingleAsync(x => x.Id == entity.Id);
+        loaded.Content.Is("updated");
+        loaded.CreatedAt.Is(appCreated);
+        loaded.UpdatedAt.Is(appUpdated2);
+
+        // act — upsert (insert-or-update) through the same pipeline; manual timestamps still untouched
+        var appUpdated3 = Instant.FromUtc(2023, 1, 1, 0, 0, 0);
+        entity.SetContent("upserted");
+        entity.SetUpdatedAt(appUpdated3);
+        await conn.GetTable<ManualTimeEntity>().InsertOrUpdateAsync(entity);
+
+        // assert
+        loaded = await conn.GetTable<ManualTimeEntity>().SingleAsync(x => x.Id == entity.Id);
+        loaded.Content.Is("upserted");
+        loaded.CreatedAt.Is(appCreated);
+        loaded.UpdatedAt.Is(appUpdated3);
+    }
+
+    /// <summary>
+    /// Tests that updating an entity with a composite primary key targets only the row matching
+    /// every key column, exercising the AndAlso-aggregation branch of the predicate builder.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    protected async Task Update_CompositeKey_Base()
+    {
+        // arrange
+        var timeManager = Get<ITimeManager>();
+        timeManager.SetNow(SystemClock.Instance.GetCurrentInstant());
+        await using var scope = Provider.GetConnectionScope<Connection>();
+        scope.ThrowIfDisposed();
+        var conn = scope.Cn;
+        var company = new Company(Name(), new CompanyMetadata("somewhere"));
+        var emp1 = new Employee(Name(), null);
+        var emp2 = new Employee(Name(), null);
+        await conn.Companies.InsertAsync(company);
+        await conn.Employees.InsertAsync(emp1);
+        await conn.Employees.InsertAsync(emp2);
+        // both rows share CompanyId and differ only by EmployeeId, so a predicate that ignored
+        // EmployeeId would wrongly update ce2 as well
+        var ce1 = new CompanyEmployee(company, emp1, "role-1");
+        var ce2 = new CompanyEmployee(company, emp2, "role-2");
+        await conn.CompanyEmployees.InsertAsync(ce1);
+        await conn.CompanyEmployees.InsertAsync(ce2);
+
+        // act
+        ce1.SetRole("role-1-updated");
+        await conn.CompanyEmployees.UpdateAsync(ce1);
+
+        // assert — only the composite-key-matched row changed
+        var reloaded1 = await conn.CompanyEmployees.SingleAsync(x =>
+            x.CompanyId == company.Id && x.EmployeeId == emp1.Id
+        );
+        reloaded1.Role.Is("role-1-updated");
+        var reloaded2 = await conn.CompanyEmployees.SingleAsync(x =>
+            x.CompanyId == company.Id && x.EmployeeId == emp2.Id
+        );
+        reloaded2.Role.Is("role-2");
+    }
+
+    /// <summary>
+    /// Tests that updating an entity whose table has no primary key throws, pinning the
+    /// empty-sequence behavior of the primary-key predicate builder.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    protected async Task Update_NoPrimaryKey_Throws_Base()
+    {
+        // arrange
+        await using var scope = Provider.GetConnectionScope<Connection>();
+        scope.ThrowIfDisposed();
+        var conn = scope.Cn;
+        var entity = new NoPkEntity("value");
+
+        // act + assert — the predicate builder aggregates over zero primary-key columns
+        await Wrap.It(async () => await conn.GetTable<NoPkEntity>().UpdateAsync(entity))
+            .ThrowsAsync<InvalidOperationException>();
+    }
+
+    /// <summary>
     /// Generates a unique name for test entities.
     /// </summary>
     /// <returns>A unique string identifier.</returns>

--- a/integrations/linq2db/tests/Annium.linq2db.Tests.Lib/IntegrationTestsBase.cs
+++ b/integrations/linq2db/tests/Annium.linq2db.Tests.Lib/IntegrationTestsBase.cs
@@ -60,7 +60,6 @@ public class IntegrationTestsBase : TestBase
             .AsQueryable()
             .SingleAsync(x => x.Name == companyName);
         company.Name.Is(companyName);
-        // company.CreatedAt.Is(createdAt);
         company.Metadata.Is(metadata);
         company.Employees.Has(2);
         // chief

--- a/integrations/linq2db/tests/Annium.linq2db.Tests.Lib/Models/ScopeTestsBase.cs
+++ b/integrations/linq2db/tests/Annium.linq2db.Tests.Lib/Models/ScopeTestsBase.cs
@@ -1,0 +1,339 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Annium.Core.Runtime.Time;
+using Annium.linq2db.Extensions;
+using Annium.linq2db.Tests.Lib.Db;
+using Annium.linq2db.Tests.Lib.Db.Models;
+using Annium.Testing;
+using LinqToDB;
+using LinqToDB.Async;
+using Microsoft.Extensions.DependencyInjection;
+using NodaTime;
+using Xunit;
+
+namespace Annium.linq2db.Tests.Lib.Models;
+
+/// <summary>
+/// Base class providing shared tests for the connection/transaction scope structs and the
+/// service-provider extensions that create them (rollback-on-dispose, double-dispose safety,
+/// disposed-state guards, and disposed-provider recovery).
+/// </summary>
+public class ScopeTestsBase : TestBase
+{
+    protected ScopeTestsBase(ITestOutputHelper outputHelper)
+        : base(outputHelper)
+    {
+        RegisterServicePack<LibServicePack>();
+    }
+
+    /// <summary>
+    /// Verifies a transaction scope rolls its work back when disposed without an explicit commit.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    protected async Task TransactionScope_RollsBackOnDispose_Base()
+    {
+        // arrange
+        var timeManager = Get<ITimeManager>();
+        timeManager.SetNow(SystemClock.Instance.GetCurrentInstant());
+        var name = Guid.NewGuid().ToString();
+
+        // act — insert inside a transaction scope, then dispose without committing
+        await using (var txnScope = Provider.GetTransactionScope<Connection>())
+        {
+            txnScope.ThrowIfDisposed();
+            var (conn, _) = txnScope;
+            await conn.Companies.InsertAsync(new Company(name, new CompanyMetadata("somewhere")));
+            // visible within the transaction
+            (await conn.Companies.Where(x => x.Name == name).CountAsync()).Is(1);
+        }
+
+        // assert — a fresh connection sees no row (the transaction rolled back)
+        await using var verify = Provider.GetConnectionScope<Connection>();
+        verify.ThrowIfDisposed();
+        (await verify.Cn.Companies.Where(x => x.Name == name).CountAsync()).Is(0);
+    }
+
+    /// <summary>
+    /// Verifies disposing a disposed-state transaction scope (as returned by the factory's
+    /// ObjectDisposedException path) is a guarded no-op rather than throwing, for every arity.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    protected async Task TransactionScope_DisposedState_DisposeIsNoop_Base()
+    {
+        var s1 = new TransactionScope<Connection>(true);
+        s1.IsDisposed.IsTrue();
+        await s1.DisposeAsync();
+
+        var s2 = new TransactionScope<Connection, Connection>(true);
+        await s2.DisposeAsync();
+
+        var s3 = new TransactionScope<Connection, Connection, Connection>(true);
+        await s3.DisposeAsync();
+
+        var s4 = new TransactionScope<Connection, Connection, Connection, Connection>(true);
+        await s4.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Verifies disposing a disposed-state connection scope (as returned by the factory's
+    /// ObjectDisposedException path) is a guarded no-op rather than throwing, for every arity.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    protected async Task ConnectionScope_DisposedState_DisposeIsNoop_Base()
+    {
+        var c1 = new ConnectionScope<Connection>(true);
+        c1.IsDisposed.IsTrue();
+        await c1.DisposeAsync();
+
+        var c2 = new ConnectionScope<Connection, Connection>(true);
+        await c2.DisposeAsync();
+
+        var c3 = new ConnectionScope<Connection, Connection, Connection>(true);
+        await c3.DisposeAsync();
+
+        var c4 = new ConnectionScope<Connection, Connection, Connection, Connection>(true);
+        await c4.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Verifies a disposed-state transaction scope reports disposal and guards its accessors for every arity.
+    /// </summary>
+    protected void TransactionScope_DisposedState_Throws_Base()
+    {
+        var s1 = new TransactionScope<Connection>(true);
+        s1.IsDisposed.IsTrue();
+        Wrap.It(() => s1.ThrowIfDisposed()).Throws<ObjectDisposedException>();
+        Wrap.It(() =>
+            {
+                var (_, _) = s1;
+            })
+            .Throws<ObjectDisposedException>();
+
+        var s2 = new TransactionScope<Connection, Connection>(true);
+        s2.IsDisposed.IsTrue();
+        Wrap.It(() => s2.ThrowIfDisposed()).Throws<ObjectDisposedException>();
+        Wrap.It(() =>
+            {
+                var (_, _, _, _) = s2;
+            })
+            .Throws<ObjectDisposedException>();
+
+        var s3 = new TransactionScope<Connection, Connection, Connection>(true);
+        s3.IsDisposed.IsTrue();
+        Wrap.It(() => s3.ThrowIfDisposed()).Throws<ObjectDisposedException>();
+        Wrap.It(() =>
+            {
+                var (_, _, _, _, _, _) = s3;
+            })
+            .Throws<ObjectDisposedException>();
+
+        var s4 = new TransactionScope<Connection, Connection, Connection, Connection>(true);
+        s4.IsDisposed.IsTrue();
+        Wrap.It(() => s4.ThrowIfDisposed()).Throws<ObjectDisposedException>();
+        Wrap.It(() =>
+            {
+                var (_, _, _, _, _, _, _, _) = s4;
+            })
+            .Throws<ObjectDisposedException>();
+    }
+
+    /// <summary>
+    /// Verifies a disposed-state connection scope reports disposal and guards its accessors for every arity.
+    /// </summary>
+    protected void ConnectionScope_DisposedState_Throws_Base()
+    {
+        var c1 = new ConnectionScope<Connection>(true);
+        c1.IsDisposed.IsTrue();
+        Wrap.It(() => c1.ThrowIfDisposed()).Throws<ObjectDisposedException>();
+
+        var c2 = new ConnectionScope<Connection, Connection>(true);
+        c2.IsDisposed.IsTrue();
+        Wrap.It(() => c2.ThrowIfDisposed()).Throws<ObjectDisposedException>();
+        Wrap.It(() =>
+            {
+                var (_, _) = c2;
+            })
+            .Throws<ObjectDisposedException>();
+
+        var c3 = new ConnectionScope<Connection, Connection, Connection>(true);
+        c3.IsDisposed.IsTrue();
+        Wrap.It(() => c3.ThrowIfDisposed()).Throws<ObjectDisposedException>();
+        Wrap.It(() =>
+            {
+                var (_, _, _) = c3;
+            })
+            .Throws<ObjectDisposedException>();
+
+        var c4 = new ConnectionScope<Connection, Connection, Connection, Connection>(true);
+        c4.IsDisposed.IsTrue();
+        Wrap.It(() => c4.ThrowIfDisposed()).Throws<ObjectDisposedException>();
+        Wrap.It(() =>
+            {
+                var (_, _, _, _) = c4;
+            })
+            .Throws<ObjectDisposedException>();
+    }
+
+    /// <summary>
+    /// Verifies creating a connection scope from a disposed provider yields a disposed scope instead of throwing.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    protected async Task GetConnectionScope_DisposedProvider_ReturnsDisposedScope_Base()
+    {
+        var inner = Provider.CreateAsyncScope();
+        var sp = inner.ServiceProvider;
+        await inner.DisposeAsync();
+
+        sp.GetConnectionScope<Connection>().IsDisposed.IsTrue();
+        sp.GetConnectionScope<Connection, ConnectionB>().IsDisposed.IsTrue();
+        sp.GetConnectionScope<Connection, ConnectionB, ConnectionC>().IsDisposed.IsTrue();
+        sp.GetConnectionScope<Connection, ConnectionB, ConnectionC, ConnectionD>().IsDisposed.IsTrue();
+    }
+
+    /// <summary>
+    /// Verifies creating a transaction scope from a disposed provider yields a disposed scope instead of throwing.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    protected async Task GetTransactionScope_DisposedProvider_ReturnsDisposedScope_Base()
+    {
+        var inner = Provider.CreateAsyncScope();
+        var sp = inner.ServiceProvider;
+        await inner.DisposeAsync();
+
+        sp.GetTransactionScope<Connection>().IsDisposed.IsTrue();
+        sp.GetTransactionScope<Connection, ConnectionB>().IsDisposed.IsTrue();
+        sp.GetTransactionScope<Connection, ConnectionB, ConnectionC>().IsDisposed.IsTrue();
+        sp.GetTransactionScope<Connection, ConnectionB, ConnectionC, ConnectionD>().IsDisposed.IsTrue();
+    }
+
+    /// <summary>
+    /// Verifies the multi-arity connection scope overloads resolve distinct, independently usable
+    /// connections against a live provider and dispose cleanly.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    protected async Task ConnectionScope_MultiArity_Live_Base()
+    {
+        var timeManager = Get<ITimeManager>();
+        timeManager.SetNow(SystemClock.Instance.GetCurrentInstant());
+
+        // 2-arity — insert via the first connection, read back via the second to prove both
+        // distinct connections are resolved and operate against the same database
+        await using (var s2 = Provider.GetConnectionScope<Connection, ConnectionB>())
+        {
+            s2.ThrowIfDisposed();
+            var (c1, c2) = s2;
+            var name = Guid.NewGuid().ToString();
+            await c1.GetTable<Company>().InsertAsync(new Company(name, new CompanyMetadata("somewhere")));
+            (await c2.GetTable<Company>().Where(x => x.Name == name).CountAsync()).Is(1);
+        }
+
+        // 3-arity — all three connections resolve to distinct, non-null instances
+        await using (var s3 = Provider.GetConnectionScope<Connection, ConnectionB, ConnectionC>())
+        {
+            s3.ThrowIfDisposed();
+            var (c1, c2, c3) = s3;
+            c1.IsNotDefault();
+            c2.IsNotDefault();
+            c3.IsNotDefault();
+        }
+
+        // 4-arity — insert via the first connection, read back via the fourth
+        await using (var s4 = Provider.GetConnectionScope<Connection, ConnectionB, ConnectionC, ConnectionD>())
+        {
+            s4.ThrowIfDisposed();
+            var (c1, _, _, c4) = s4;
+            var name = Guid.NewGuid().ToString();
+            await c1.GetTable<Company>().InsertAsync(new Company(name, new CompanyMetadata("somewhere")));
+            (await c4.GetTable<Company>().Where(x => x.Name == name).CountAsync()).Is(1);
+        }
+    }
+
+    /// <summary>
+    /// Verifies the 2-arity transaction scope rolls back both connections' work on dispose.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    protected async Task TransactionScope_TwoArity_RollsBackOnDispose_Base()
+    {
+        var timeManager = Get<ITimeManager>();
+        timeManager.SetNow(SystemClock.Instance.GetCurrentInstant());
+        var n1 = Guid.NewGuid().ToString();
+        var n2 = Guid.NewGuid().ToString();
+
+        await using (var scope = Provider.GetTransactionScope<Connection, ConnectionB>())
+        {
+            scope.ThrowIfDisposed();
+            var (c1, _, c2, _) = scope;
+            await c1.GetTable<Company>().InsertAsync(new Company(n1, new CompanyMetadata("somewhere")));
+            await c2.GetTable<Company>().InsertAsync(new Company(n2, new CompanyMetadata("somewhere")));
+            (await c1.GetTable<Company>().Where(x => x.Name == n1).CountAsync()).Is(1);
+        }
+
+        await using var verify = Provider.GetConnectionScope<Connection>();
+        verify.ThrowIfDisposed();
+        var names = new[] { n1, n2 };
+        (await verify.Cn.GetTable<Company>().Where(x => names.Contains(x.Name)).CountAsync()).Is(0);
+    }
+
+    /// <summary>
+    /// Verifies the 3-arity transaction scope rolls back all three connections' work on dispose.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    protected async Task TransactionScope_ThreeArity_RollsBackOnDispose_Base()
+    {
+        var timeManager = Get<ITimeManager>();
+        timeManager.SetNow(SystemClock.Instance.GetCurrentInstant());
+        var n1 = Guid.NewGuid().ToString();
+        var n2 = Guid.NewGuid().ToString();
+        var n3 = Guid.NewGuid().ToString();
+
+        await using (var scope = Provider.GetTransactionScope<Connection, ConnectionB, ConnectionC>())
+        {
+            scope.ThrowIfDisposed();
+            var (c1, _, c2, _, c3, _) = scope;
+            await c1.GetTable<Company>().InsertAsync(new Company(n1, new CompanyMetadata("somewhere")));
+            await c2.GetTable<Company>().InsertAsync(new Company(n2, new CompanyMetadata("somewhere")));
+            await c3.GetTable<Company>().InsertAsync(new Company(n3, new CompanyMetadata("somewhere")));
+            (await c1.GetTable<Company>().Where(x => x.Name == n1).CountAsync()).Is(1);
+        }
+
+        await using var verify = Provider.GetConnectionScope<Connection>();
+        verify.ThrowIfDisposed();
+        var names = new[] { n1, n2, n3 };
+        (await verify.Cn.GetTable<Company>().Where(x => names.Contains(x.Name)).CountAsync()).Is(0);
+    }
+
+    /// <summary>
+    /// Verifies the 4-arity transaction scope rolls back every connection's work on dispose.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    protected async Task TransactionScope_MultiArity_RollsBackOnDispose_Base()
+    {
+        var timeManager = Get<ITimeManager>();
+        timeManager.SetNow(SystemClock.Instance.GetCurrentInstant());
+        var n1 = Guid.NewGuid().ToString();
+        var n2 = Guid.NewGuid().ToString();
+        var n3 = Guid.NewGuid().ToString();
+        var n4 = Guid.NewGuid().ToString();
+
+        // act — each distinct connection inserts a row in its own transaction, then the scope is
+        // disposed without committing
+        await using (var scope = Provider.GetTransactionScope<Connection, ConnectionB, ConnectionC, ConnectionD>())
+        {
+            scope.ThrowIfDisposed();
+            var (c1, _, c2, _, c3, _, c4, _) = scope;
+            await c1.GetTable<Company>().InsertAsync(new Company(n1, new CompanyMetadata("somewhere")));
+            await c2.GetTable<Company>().InsertAsync(new Company(n2, new CompanyMetadata("somewhere")));
+            await c3.GetTable<Company>().InsertAsync(new Company(n3, new CompanyMetadata("somewhere")));
+            await c4.GetTable<Company>().InsertAsync(new Company(n4, new CompanyMetadata("somewhere")));
+            // visible within its own transaction
+            (await c1.GetTable<Company>().Where(x => x.Name == n1).CountAsync()).Is(1);
+        }
+
+        // assert — a fresh connection sees none of the four rows (all transactions rolled back)
+        await using var verify = Provider.GetConnectionScope<Connection>();
+        verify.ThrowIfDisposed();
+        var names = new[] { n1, n2, n3, n4 };
+        (await verify.Cn.GetTable<Company>().Where(x => names.Contains(x.Name)).CountAsync()).Is(0);
+    }
+}


### PR DESCRIPTION
…ak hardening, tests 7→23

- fix: ConfigureManual* entities no longer throw through a ProcessQuery-auto Connection — auto-timestamp pipeline graceful-skips skip-flagged columns (ResolveTimeColumns uses TryFindColumn + null-guards each column)
- fix: BuildUpdateSetter excluded PK via the wrong attribute (ColumnAttribute .IsPrimaryKey, never set by fluent HasPrimaryKey) → PK columns leaked into the UPDATE SET clause; now excludes via c.PrimaryKey is null
- fix: scope factories (GetConnection/TransactionScope) dispose the AsyncServiceScope on non-ObjectDisposedException errors (DisposeSafely); scope DisposeAsync wraps rollback/dispose in try/finally so error paths can't leak the scope/connection
- fix: remove redundant `f != null!` dead condition
- design: correct scope DisposeAsync doc contract; AddEntityConfigurations idempotent; add missing <exception> tags; correct copy-paste <param> docs; DataSourceContainer now IAsyncDisposable
- refactor: rename TableInsertOrUpdateExtensions.cs → TableSaveExtensions.cs; extract ResolveTimeColumns / BuildBindings helpers; drop redundant PK config lines
- test: 7→23 — scope lifecycle/disposal/recovery all arities, composite-PK, zero-PK throw, created-only + manual timestamp paths (new fixtures + migrations 004/005)