### PR TITLE
test(redis): cover config + storage branch/fault paths; DRY connectio…

### DIFF
--- a/integrations/Redis/src/Annium.Redis/IRedisStorage.cs
+++ b/integrations/Redis/src/Annium.Redis/IRedisStorage.cs
@@ -21,7 +21,7 @@ public interface IRedisStorage
     /// <summary>
     /// Retrieves all keys matching the specified pattern.
     /// </summary>
-    /// <param name="pattern">The pattern to match keys against (empty string matches all keys).</param>
+    /// <param name="pattern">The pattern to match keys against (an empty or whitespace-only string matches all keys).</param>
     /// <param name="ct">Cancellation token observed at the connection gate and during keyspace enumeration.</param>
     /// <returns>A collection of matching keys.</returns>
     Task<IReadOnlyCollection<string>> GetKeysAsync(string pattern = "", CancellationToken ct = default);

--- a/integrations/Redis/src/Annium.Redis/Internal/RedisStorage.cs
+++ b/integrations/Redis/src/Annium.Redis/Internal/RedisStorage.cs
@@ -53,13 +53,12 @@ internal class RedisStorage : IRedisStorage, IAsyncDisposable
     /// Enumerates all keys across every connected Redis server whose names match the given glob pattern.
     /// An empty or whitespace <paramref name="pattern"/> matches every key.
     /// </summary>
-    /// <param name="pattern">Glob pattern used to filter keys (e.g. <c>session:*</c>). Pass an empty string to match all keys.</param>
+    /// <param name="pattern">Glob pattern used to filter keys (e.g. <c>session:*</c>). Pass an empty or whitespace-only string to match all keys.</param>
     /// <param name="ct">Cancellation token that cancels the key-scan operation.</param>
     /// <returns>A read-only set of key names that matched the pattern across all servers.</returns>
     public async Task<IReadOnlyCollection<string>> GetKeysAsync(string pattern = "", CancellationToken ct = default)
     {
-        ct.ThrowIfCancellationRequested();
-        var redis = await GetMultiplexerAsync().WaitAsync(ct);
+        var redis = await GetConnectedMultiplexerAsync(ct);
         var keyPattern = string.IsNullOrWhiteSpace(pattern) ? default : new RedisValue(pattern);
         var keys = new HashSet<string>();
 
@@ -80,8 +79,7 @@ internal class RedisStorage : IRedisStorage, IAsyncDisposable
     /// <returns>The stored string value, or <see langword="null"/> if the key is absent.</returns>
     public async Task<string?> GetAsync(string key, CancellationToken ct = default)
     {
-        ct.ThrowIfCancellationRequested();
-        var redis = await GetMultiplexerAsync().WaitAsync(ct);
+        var redis = await GetConnectedMultiplexerAsync(ct);
         var value = await redis.GetDatabase().StringGetAsync(key);
 
         return value.IsNull ? null : value.ToString();
@@ -103,8 +101,7 @@ internal class RedisStorage : IRedisStorage, IAsyncDisposable
         CancellationToken ct = default
     )
     {
-        ct.ThrowIfCancellationRequested();
-        var redis = await GetMultiplexerAsync().WaitAsync(ct);
+        var redis = await GetConnectedMultiplexerAsync(ct);
         var result = await redis
             .GetDatabase()
             .StringSetAsync(key, value, expires == Duration.Zero ? null : expires.ToTimeSpan(), When.Always);
@@ -120,8 +117,7 @@ internal class RedisStorage : IRedisStorage, IAsyncDisposable
     /// <returns><see langword="true"/> if the key existed and was deleted; <see langword="false"/> if the key was not found.</returns>
     public async Task<bool> DeleteAsync(string key, CancellationToken ct = default)
     {
-        ct.ThrowIfCancellationRequested();
-        var redis = await GetMultiplexerAsync().WaitAsync(ct);
+        var redis = await GetConnectedMultiplexerAsync(ct);
         var result = await redis.GetDatabase().KeyDeleteAsync(key);
 
         return result;
@@ -162,6 +158,19 @@ internal class RedisStorage : IRedisStorage, IAsyncDisposable
 #pragma warning disable VSTHRD011, VSTHRD003
     private Task<ConnectionMultiplexer> GetMultiplexerAsync() => _redisLazy.Value;
 #pragma warning restore VSTHRD011, VSTHRD003
+
+    /// <summary>
+    /// Observes the supplied token at the lazy-connection gate, then returns the shared
+    /// <see cref="ConnectionMultiplexer"/> — the connection wait itself is cancellable via
+    /// <paramref name="ct"/>. Centralizes the connection-gate preamble shared by every public operation.
+    /// </summary>
+    /// <param name="ct">Cancellation token observed at the connection gate.</param>
+    /// <returns>A <see cref="Task{TResult}"/> that resolves to the shared <see cref="ConnectionMultiplexer"/>.</returns>
+    private async Task<ConnectionMultiplexer> GetConnectedMultiplexerAsync(CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+        return await GetMultiplexerAsync().WaitAsync(ct);
+    }
 
     /// <summary>
     /// Opens a new <see cref="ConnectionMultiplexer"/> connection using the configuration supplied at construction time.

--- a/integrations/Redis/tests/Annium.Redis.Tests/RedisConfigurationTests.cs
+++ b/integrations/Redis/tests/Annium.Redis.Tests/RedisConfigurationTests.cs
@@ -1,0 +1,97 @@
+using Annium.Testing;
+using Xunit;
+
+namespace Annium.Redis.Tests;
+
+/// <summary>
+/// Tests for <see cref="RedisConfiguration.GetConnectionString"/> covering host joining and
+/// optional user/password suffix composition.
+/// </summary>
+public class RedisConfigurationTests
+{
+    /// <summary>
+    /// Verifies multiple hosts are joined with a comma and no user/password suffix is appended
+    /// when both are empty.
+    /// </summary>
+    [Fact]
+    public void GetConnectionString_MultipleHosts_JoinsWithComma()
+    {
+        // arrange
+        var config = new RedisConfiguration { Hosts = [new RedisHost("h1", 1), new RedisHost("h2", 2)] };
+
+        // act
+        var connectionString = config.GetConnectionString();
+
+        // assert
+        connectionString.Is("h1:1,h2:2");
+    }
+
+    /// <summary>
+    /// Verifies a set User with an empty Password appends only the user suffix.
+    /// </summary>
+    [Fact]
+    public void GetConnectionString_UserSetPasswordEmpty_AppendsUserOnly()
+    {
+        // arrange
+        var config = new RedisConfiguration { Hosts = [new RedisHost("h1", 1)], User = "u" };
+
+        // act
+        var connectionString = config.GetConnectionString();
+
+        // assert
+        connectionString.Is("h1:1,user=u");
+    }
+
+    /// <summary>
+    /// Verifies a set Password with an empty User appends only the password suffix.
+    /// </summary>
+    [Fact]
+    public void GetConnectionString_PasswordSetUserEmpty_AppendsPasswordOnly()
+    {
+        // arrange
+        var config = new RedisConfiguration { Hosts = [new RedisHost("h1", 1)], Password = "p" };
+
+        // act
+        var connectionString = config.GetConnectionString();
+
+        // assert
+        connectionString.Is("h1:1,password=p");
+    }
+
+    /// <summary>
+    /// Verifies both User and Password set appends both suffixes, user before password.
+    /// </summary>
+    [Fact]
+    public void GetConnectionString_UserAndPasswordSet_AppendsBothInOrder()
+    {
+        // arrange
+        var config = new RedisConfiguration
+        {
+            Hosts = [new RedisHost("h1", 1)],
+            User = "u",
+            Password = "p",
+        };
+
+        // act
+        var connectionString = config.GetConnectionString();
+
+        // assert
+        connectionString.Is("h1:1,user=u,password=p");
+    }
+
+    /// <summary>
+    /// Verifies neither suffix is appended when both User and Password are empty.
+    /// </summary>
+    [Fact]
+    public void GetConnectionString_UserAndPasswordEmpty_AppendsNeitherSuffix()
+    {
+        // arrange
+        var config = new RedisConfiguration { Hosts = [new RedisHost("h1", 1)] };
+
+        // act
+        var connectionString = config.GetConnectionString();
+
+        // assert
+        connectionString.Is("h1:1");
+    }
+}

--- a/integrations/Redis/tests/Annium.Redis.Tests/RedisStorageConnectionFaultTests.cs
+++ b/integrations/Redis/tests/Annium.Redis.Tests/RedisStorageConnectionFaultTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Threading.Tasks;
+using Annium.Core.DependencyInjection;
+using Annium.Testing;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Annium.Redis.Tests;
+
+/// <summary>
+/// Tests for <see cref="IRedisStorage"/> connection-fault handling against an unreachable Redis
+/// host. These build a standalone DI provider (rather than the shared Testcontainers-backed
+/// <see cref="ServicePack"/>) so the underlying <see cref="ConnectionMultiplexer"/> connect is
+/// guaranteed to fault.
+/// </summary>
+public class RedisStorageConnectionFaultTests
+{
+    /// <summary>
+    /// Verifies that disposing a storage instance whose lazy connect has faulted does not throw —
+    /// the <c>DisposeAsync</c> catch swallows the faulted connect.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation</returns>
+    [Fact]
+    public async Task DisposeAsync_ConnectionFaulted_DoesNotThrow()
+    {
+        // arrange
+        var storage = BuildUnreachableStorage();
+
+        // trigger the lazy connect and let it fault
+        await Wrap.It(async () => await storage.GetAsync(Guid.NewGuid().ToString()))
+            .ThrowsAsync<RedisConnectionException>();
+
+        // act
+        var disposable = (IAsyncDisposable)storage;
+
+        // assert
+        await disposable.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Verifies that a connection fault is not transient state that a later call silently recovers
+    /// from: once the lazy connect against an unreachable host has faulted, subsequent calls keep
+    /// throwing. (This asserts fault persistence only — it does not distinguish a reused faulted
+    /// task from a fresh per-call reconnect, since both surface the same fault against a genuinely
+    /// unreachable socket; observing same-task reuse would require an injectable connect seam.)
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation</returns>
+    [Fact]
+    public async Task ConnectionFault_PersistsAcrossCalls_AllThrow()
+    {
+        // arrange
+        var storage = BuildUnreachableStorage();
+
+        // act / assert: both calls observe the connection fault
+        await Wrap.It(async () => await storage.GetAsync(Guid.NewGuid().ToString()))
+            .ThrowsAsync<RedisConnectionException>();
+        await Wrap.It(async () => await storage.GetAsync(Guid.NewGuid().ToString()))
+            .ThrowsAsync<RedisConnectionException>();
+    }
+
+    /// <summary>
+    /// Builds a standalone <see cref="IRedisStorage"/> configured to point at an unreachable host
+    /// (connection refused), so the lazy connect faults quickly instead of hanging.
+    /// </summary>
+    /// <returns>An <see cref="IRedisStorage"/> backed by an unreachable Redis endpoint.</returns>
+    private static IRedisStorage BuildUnreachableStorage()
+    {
+        var container = new ServiceContainer();
+        container.Add(new RedisConfiguration { Hosts = [new RedisHost("127.0.0.1", 1)] }).AsSelf().Singleton();
+        container.AddRedis();
+
+        var provider = container.BuildServiceProvider();
+
+        return provider.Resolve<IRedisStorage>();
+    }
+}

--- a/integrations/Redis/tests/Annium.Redis.Tests/RedisStorageTests.cs
+++ b/integrations/Redis/tests/Annium.Redis.Tests/RedisStorageTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Annium.Testing;
@@ -107,6 +108,51 @@ public class RedisStorageTests : TestBase
 
         // ensure no data
         await EnsureDataIsEmpty(storage, key, ct);
+    }
+
+    /// <summary>
+    /// Tests that deleting a key that was never set reports false, per the documented contract
+    /// ("false if it didn't exist").
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation</returns>
+    [Fact]
+    public async Task DeleteAsync_KeyAbsent_ReturnsFalse()
+    {
+        // arrange
+        var storage = Get<IRedisStorage>();
+        var key = Guid.NewGuid().ToString();
+        var ct = TestContext.Current.CancellationToken;
+
+        // act
+        var result = await storage.DeleteAsync(key, ct);
+
+        // assert
+        result.IsFalse();
+    }
+
+    /// <summary>
+    /// Tests that GetKeysAsync with an empty pattern matches all keys, per the documented contract
+    /// ("empty string matches all keys"), by asserting known keys are present among the results.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation</returns>
+    [Fact]
+    public async Task GetKeysAsync_EmptyPattern_ReturnsAllKeys()
+    {
+        // arrange
+        var storage = Get<IRedisStorage>();
+        var keyA = Guid.NewGuid().ToString();
+        var keyB = Guid.NewGuid().ToString();
+        var ct = TestContext.Current.CancellationToken;
+
+        await storage.SetAsync(keyA, "a", ct: ct);
+        await storage.SetAsync(keyB, "b", ct: ct);
+
+        // act
+        var keys = await storage.GetKeysAsync(ct: ct);
+
+        // assert
+        keys.Contains(keyA).IsTrue();
+        keys.Contains(keyB).IsTrue();
     }
 
     /// <summary>
@@ -240,6 +286,17 @@ public class RedisStorageTests : TestBase
         CancellationToken ct
     )
     {
+        // key[2..10] extracts an 8-char slice from the middle of the key to build a
+        // substring glob. This assumes every caller passes a Guid.NewGuid().ToString()
+        // key (36 chars, hyphenated) — the slice is a stable, collision-unlikely fragment
+        // for match-by-pattern. Guard the assumption so a non-GUID key fails loudly here
+        // rather than silently building a nonsensical pattern.
+        if (key.Length < 10)
+            throw new ArgumentException(
+                $"LoadData expects a GUID-format key; got '{key}' (length {key.Length}).",
+                nameof(key)
+            );
+
         var pattern = $"*{key[2..10]}*";
 
         // find keys and try get value


### PR DESCRIPTION
…n gate

- add RedisConfigurationTests (host-join, user/pass connection-string branches)
- cover GetKeysAsync empty-pattern match-all and DeleteAsync key-absent → false
- add connection-fault tests (dispose-after-fault no-throw, fault persists across calls)
- guard LoadData test helper against non-GUID keys
- fix GetKeysAsync doc drift (empty or whitespace-only matches all)
- extract shared GetConnectedMultiplexerAsync connection gate across the 4 public methods