### PR TITLE
feat(cache): implement Annium.Cache.Redis skeleton on Annium.Redis IR…

### DIFF
--- a/base/Cache/src/Annium.Cache.InMemory/Internal/Cache.cs
+++ b/base/Cache/src/Annium.Cache.InMemory/Internal/Cache.cs
@@ -69,8 +69,7 @@ internal class Cache<TKey, TValue> : ICache<TKey, TValue>, ILogSubject
     )
         where TContext : notnull
     {
-        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
-        ct.ThrowIfCancellationRequested();
+        EnsureUsable(ct);
 
         var entry = GetOrCreateEntry(key, factory, context, options);
         // VSTHRD003: Tcs.Task is the cache's own shared per-key work, not a foreign task; awaiting it
@@ -88,13 +87,22 @@ internal class Cache<TKey, TValue> : ICache<TKey, TValue>, ILogSubject
     /// <returns>A value task that represents the asynchronous remove operation</returns>
     public ValueTask RemoveAsync(TKey key, CancellationToken ct = default)
     {
-        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
-        ct.ThrowIfCancellationRequested();
+        EnsureUsable(ct);
 
         lock (_data)
             _data.Remove(key);
 
         return ValueTask.CompletedTask;
+    }
+
+    /// <summary>
+    /// Throws if the cache is disposed or the caller's token is already cancelled.
+    /// </summary>
+    /// <param name="ct">The caller's cancellation token.</param>
+    private void EnsureUsable(CancellationToken ct)
+    {
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+        ct.ThrowIfCancellationRequested();
     }
 
     /// <summary>

--- a/base/Cache/src/Annium.Cache.Redis/Annium.Cache.Redis.csproj
+++ b/base/Cache/src/Annium.Cache.Redis/Annium.Cache.Redis.csproj
@@ -6,8 +6,8 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="../Annium.Cache.Abstractions/Annium.Cache.Abstractions.csproj" />
     <ProjectReference Include="../../../../integrations/Redis/src/Annium.Redis/Annium.Redis.csproj" />
+    <ProjectReference Include="../Annium.Cache.Abstractions/Annium.Cache.Abstractions.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Annium.Core.DependencyInjection" />

--- a/base/Cache/src/Annium.Cache.Redis/Annium.Cache.Redis.csproj
+++ b/base/Cache/src/Annium.Cache.Redis/Annium.Cache.Redis.csproj
@@ -7,5 +7,11 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../Annium.Cache.Abstractions/Annium.Cache.Abstractions.csproj" />
+    <ProjectReference Include="../../../../integrations/Redis/src/Annium.Redis/Annium.Redis.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Annium.Core.DependencyInjection" />
+    <PackageReference Include="Annium.Core.Runtime" />
+    <PackageReference Include="Annium.Serialization.Abstractions" />
   </ItemGroup>
 </Project>

--- a/base/Cache/src/Annium.Cache.Redis/Internal/Cache.cs
+++ b/base/Cache/src/Annium.Cache.Redis/Internal/Cache.cs
@@ -2,27 +2,70 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Annium.Cache.Abstractions;
+using Annium.Logging;
+using Annium.Redis;
 
 namespace Annium.Cache.Redis.Internal;
 
 /// <summary>
-/// Redis-based cache implementation (stub — pending dedicated design; see kb/concepts for upcoming Cache.Redis design)
+/// Redis-backed cache implementation of <see cref="ICache{TKey,TValue}"/>, built on the shared
+/// <see cref="IRedisStorage"/> abstraction from <c>Annium.Redis</c>.
 /// </summary>
-/// <typeparam name="TKey">The type of cache keys</typeparam>
-/// <typeparam name="TValue">The type of cached values</typeparam>
-internal class Cache<TKey, TValue> : ICache<TKey, TValue>
+/// <remarks>
+/// The connection is owned by <see cref="IRedisStorage"/> (a DI-managed singleton), so this cache
+/// holds no connection of its own. <see cref="GetOrCreateAsync{TContext}"/> — serialization, logical
+/// expiry, and single-flight — is implemented in later tasks; this task wires storage access and the
+/// key-namespacing/disposal lifecycle, and implements <see cref="RemoveAsync"/>.
+/// </remarks>
+/// <typeparam name="TKey">The type of cache keys.</typeparam>
+/// <typeparam name="TValue">The type of cached values.</typeparam>
+internal class Cache<TKey, TValue> : ICache<TKey, TValue>, ILogSubject
     where TKey : IEquatable<TKey>
     where TValue : notnull
 {
     /// <summary>
-    /// Gets an existing item from cache or creates a new one using the provided factory
+    /// Gets the logger for this cache.
     /// </summary>
-    /// <param name="key">The cache key</param>
-    /// <param name="factory">Factory function to create the value if not found in cache</param>
-    /// <param name="context">Context object passed to the factory function</param>
-    /// <param name="options">Cache options including expiration settings</param>
-    /// <param name="ct">Cancellation token for the awaiting caller</param>
-    /// <returns>The cached or newly created value</returns>
+    public ILogger Logger { get; }
+
+    /// <summary>
+    /// The shared Redis storage backing this cache.
+    /// </summary>
+    private readonly IRedisStorage _storage;
+
+    /// <summary>
+    /// Cache-level options (notably the key prefix).
+    /// </summary>
+    private readonly RedisCacheOptions _options;
+
+    /// <summary>
+    /// Disposal flag that ensures <see cref="DisposeAsync"/> is idempotent (0 = live, 1 = disposed).
+    /// </summary>
+    private int _disposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Cache{TKey,TValue}"/> class.
+    /// </summary>
+    /// <param name="storage">The shared Redis storage.</param>
+    /// <param name="options">The cache options.</param>
+    /// <param name="logger">The logger.</param>
+    public Cache(IRedisStorage storage, RedisCacheOptions options, ILogger logger)
+    {
+        _storage = storage;
+        _options = options;
+        Logger = logger;
+    }
+
+    /// <summary>
+    /// Gets an existing item from the cache or creates a new one using the provided factory.
+    /// </summary>
+    /// <typeparam name="TContext">The type of the context object passed to the factory.</typeparam>
+    /// <param name="key">The cache key.</param>
+    /// <param name="factory">Factory function to create the value if not found in cache.</param>
+    /// <param name="context">Context object passed to the factory function.</param>
+    /// <param name="options">Cache options including expiration settings.</param>
+    /// <param name="ct">Cancellation token for the awaiting caller.</param>
+    /// <returns>The cached or newly created value.</returns>
     public ValueTask<TValue> GetOrCreateAsync<TContext>(
         TKey key,
         Func<TKey, TContext, CancellationToken, ValueTask<TValue>> factory,
@@ -36,22 +79,35 @@ internal class Cache<TKey, TValue> : ICache<TKey, TValue>
     }
 
     /// <summary>
-    /// Removes an item from the cache
+    /// Removes an item from the cache.
     /// </summary>
-    /// <param name="key">The cache key to remove</param>
-    /// <param name="ct">Cancellation token</param>
-    /// <returns>A value task that represents the asynchronous remove operation</returns>
-    public ValueTask RemoveAsync(TKey key, CancellationToken ct = default)
+    /// <param name="key">The cache key to remove.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A value task that represents the asynchronous remove operation.</returns>
+    public async ValueTask RemoveAsync(TKey key, CancellationToken ct = default)
     {
-        throw new NotImplementedException();
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+        ct.ThrowIfCancellationRequested();
+
+        await _storage.DeleteAsync(Key(key), ct);
     }
 
     /// <summary>
-    /// Disposes the cache. No-op until the Redis cache is implemented (the stub owns no resources).
+    /// Disposes the cache. Idempotent. The underlying <see cref="IRedisStorage"/> connection is owned
+    /// by the DI container, so there is nothing to release here beyond flipping the disposed flag.
     /// </summary>
-    /// <returns>A completed task.</returns>
+    /// <returns>A completed <see cref="ValueTask"/>.</returns>
     public ValueTask DisposeAsync()
     {
+        Interlocked.Exchange(ref _disposed, 1);
+
         return ValueTask.CompletedTask;
     }
+
+    /// <summary>
+    /// Builds the namespaced Redis key for a cache key by prepending the configured prefix.
+    /// </summary>
+    /// <param name="key">The cache key.</param>
+    /// <returns>The prefixed Redis key string.</returns>
+    private string Key(TKey key) => _options.KeyPrefix + key;
 }

--- a/base/Cache/src/Annium.Cache.Redis/Internal/Cache.cs
+++ b/base/Cache/src/Annium.Cache.Redis/Internal/Cache.cs
@@ -1,9 +1,14 @@
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Annium.Cache.Abstractions;
+using Annium.Core.Runtime.Time;
 using Annium.Logging;
 using Annium.Redis;
+using Annium.Serialization.Abstractions;
+using NodaTime;
 
 namespace Annium.Cache.Redis.Internal;
 
@@ -12,10 +17,12 @@ namespace Annium.Cache.Redis.Internal;
 /// <see cref="IRedisStorage"/> abstraction from <c>Annium.Redis</c>.
 /// </summary>
 /// <remarks>
-/// The connection is owned by <see cref="IRedisStorage"/> (a DI-managed singleton), so this cache
-/// holds no connection of its own. <see cref="GetOrCreateAsync{TContext}"/> — serialization, logical
-/// expiry, and single-flight — is implemented in later tasks; this task wires storage access and the
-/// key-namespacing/disposal lifecycle, and implements <see cref="RemoveAsync"/>.
+/// The connection is owned by <see cref="IRedisStorage"/> (a DI-managed singleton), so this cache holds
+/// no connection of its own. Expiry is enforced <em>logically</em> via <see cref="ITimeProvider"/> (the
+/// stored envelope carries an absolute deadline) so that managed-time tests and the InMemory contract
+/// stay aligned; Redis' physical TTL is a secondary leak-guard. Concurrent callers for the same missing
+/// key are de-duplicated in-process (single-flight), so the factory runs once per cache instance.
+/// Sliding refresh and the finer in-flight cancel/drain semantics are added in later tasks.
 /// </remarks>
 /// <typeparam name="TKey">The type of cache keys.</typeparam>
 /// <typeparam name="TValue">The type of cached values.</typeparam>
@@ -39,6 +46,21 @@ internal class Cache<TKey, TValue> : ICache<TKey, TValue>, ILogSubject
     private readonly RedisCacheOptions _options;
 
     /// <summary>
+    /// Serializer used to encode/decode the stored <see cref="CacheEnvelope{TValue}"/>.
+    /// </summary>
+    private readonly ISerializer<string> _serializer;
+
+    /// <summary>
+    /// Time provider driving logical expiry.
+    /// </summary>
+    private readonly ITimeProvider _timeProvider;
+
+    /// <summary>
+    /// In-process single-flight map: concurrent callers for the same key share one factory run.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, Task<TValue>> _inflight = new();
+
+    /// <summary>
     /// Disposal flag that ensures <see cref="DisposeAsync"/> is idempotent (0 = live, 1 = disposed).
     /// </summary>
     private int _disposed;
@@ -48,11 +70,21 @@ internal class Cache<TKey, TValue> : ICache<TKey, TValue>, ILogSubject
     /// </summary>
     /// <param name="storage">The shared Redis storage.</param>
     /// <param name="options">The cache options.</param>
+    /// <param name="serializer">The serializer for cache envelopes.</param>
+    /// <param name="timeProvider">The time provider driving logical expiry.</param>
     /// <param name="logger">The logger.</param>
-    public Cache(IRedisStorage storage, RedisCacheOptions options, ILogger logger)
+    public Cache(
+        IRedisStorage storage,
+        RedisCacheOptions options,
+        ISerializer<string> serializer,
+        ITimeProvider timeProvider,
+        ILogger logger
+    )
     {
         _storage = storage;
         _options = options;
+        _serializer = serializer;
+        _timeProvider = timeProvider;
         Logger = logger;
     }
 
@@ -66,7 +98,7 @@ internal class Cache<TKey, TValue> : ICache<TKey, TValue>, ILogSubject
     /// <param name="options">Cache options including expiration settings.</param>
     /// <param name="ct">Cancellation token for the awaiting caller.</param>
     /// <returns>The cached or newly created value.</returns>
-    public ValueTask<TValue> GetOrCreateAsync<TContext>(
+    public async ValueTask<TValue> GetOrCreateAsync<TContext>(
         TKey key,
         Func<TKey, TContext, CancellationToken, ValueTask<TValue>> factory,
         TContext context,
@@ -75,7 +107,43 @@ internal class Cache<TKey, TValue> : ICache<TKey, TValue>, ILogSubject
     )
         where TContext : notnull
     {
-        throw new NotImplementedException();
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+        ct.ThrowIfCancellationRequested();
+
+        var k = Key(key);
+
+        // fast path: return a live stored value without entering single-flight
+        var (hit, value) = await ReadLiveAsync(k, ct);
+        if (hit)
+            return value;
+
+        // miss → in-process single-flight: the caller that installs the TCS runs the factory,
+        // everyone else awaits the same task (per-caller cancellation via WaitAsync).
+        var tcs = new TaskCompletionSource<TValue>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var task = _inflight.GetOrAdd(k, tcs.Task);
+        if (task == tcs.Task)
+        {
+            try
+            {
+                tcs.TrySetResult(await CreateAsync(k, key, factory, context, options));
+            }
+            catch (Exception ex)
+            {
+                this.Trace("Factory failed for {key}", key);
+                this.Error(ex);
+                tcs.TrySetException(ex);
+            }
+            finally
+            {
+                // unpoison: the shared task is settled, so a later call re-reads / re-creates
+                _inflight.TryRemove(new KeyValuePair<string, Task<TValue>>(k, tcs.Task));
+            }
+        }
+
+        // VSTHRD003: `task` is this cache's own single-flight task (installed above), not a foreign one.
+#pragma warning disable VSTHRD003
+        return await task.WaitAsync(ct);
+#pragma warning restore VSTHRD003
     }
 
     /// <summary>
@@ -102,6 +170,66 @@ internal class Cache<TKey, TValue> : ICache<TKey, TValue>, ILogSubject
         Interlocked.Exchange(ref _disposed, 1);
 
         return ValueTask.CompletedTask;
+    }
+
+    /// <summary>
+    /// Reads the stored entry for a key and returns it only if it is logically live (not past its deadline).
+    /// </summary>
+    /// <param name="k">The prefixed Redis key.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A tuple of (hit, value); <c>hit</c> is false on a missing or logically-expired entry.</returns>
+    private async Task<(bool Hit, TValue Value)> ReadLiveAsync(string k, CancellationToken ct)
+    {
+        var raw = await _storage.GetAsync(k, ct);
+        if (raw is null)
+            return (false, default!);
+
+        var env = _serializer.Deserialize<CacheEnvelope<TValue>>(raw);
+        if (_timeProvider.Now.ToUnixTimeMilliseconds() >= env.ExpiresAtMs)
+            return (false, default!);
+
+        return (true, env.Value);
+    }
+
+    /// <summary>
+    /// The single-flight winner's work: re-check the store, invoke the factory, and write the value with
+    /// its expiry envelope. The factory runs detached from any single caller's cancellation.
+    /// </summary>
+    private async Task<TValue> CreateAsync<TContext>(
+        string k,
+        TKey key,
+        Func<TKey, TContext, CancellationToken, ValueTask<TValue>> factory,
+        TContext context,
+        CacheOptions options
+    )
+        where TContext : notnull
+    {
+        // double-check: another process may have written between our fast-path read and here
+        var (hit, value) = await ReadLiveAsync(k, CancellationToken.None);
+        if (hit)
+            return value;
+
+        this.Trace("Create item for {key}", key);
+        value = await factory(key, context, CancellationToken.None);
+
+        var now = _timeProvider.Now;
+        var expiresAt = options.GetExpiresAt(now);
+        var envelope = new CacheEnvelope<TValue>
+        {
+            Value = value,
+            Mode = options.Mode,
+            ExpiresAtMs = expiresAt.ToUnixTimeMilliseconds(),
+            LifetimeMs = options.Mode == CacheExpirationMode.Sliding ? (long)options.Lifetime.TotalMilliseconds : null,
+        };
+
+        // physical TTL as a leak-guard; logical expiry (ExpiresAtMs vs ITimeProvider.Now) is authoritative.
+        var ttl = expiresAt - now;
+        if (ttl <= Duration.Zero)
+            ttl = Duration.FromMilliseconds(1);
+
+        await _storage.SetAsync(k, _serializer.Serialize(envelope), ttl, CancellationToken.None);
+
+        return value;
     }
 
     /// <summary>

--- a/base/Cache/src/Annium.Cache.Redis/Internal/Cache.cs
+++ b/base/Cache/src/Annium.Cache.Redis/Internal/Cache.cs
@@ -58,7 +58,7 @@ internal class Cache<TKey, TValue> : ICache<TKey, TValue>, ILogSubject
     /// <summary>
     /// In-process single-flight map: concurrent callers for the same key share one factory run.
     /// </summary>
-    private readonly ConcurrentDictionary<string, Task<TValue>> _inflight = new();
+    private readonly ConcurrentDictionary<string, Flight> _inflight = new();
 
     /// <summary>
     /// Disposal flag that ensures <see cref="DisposeAsync"/> is idempotent (0 = live, 1 = disposed).
@@ -112,38 +112,56 @@ internal class Cache<TKey, TValue> : ICache<TKey, TValue>, ILogSubject
 
         var k = Key(key);
 
-        // fast path: return a live stored value without entering single-flight
-        var (hit, value) = await ReadLiveAsync(k, ct);
-        if (hit)
-            return value;
-
-        // miss → in-process single-flight: the caller that installs the TCS runs the factory,
-        // everyone else awaits the same task (per-caller cancellation via WaitAsync).
+        // in-process single-flight: install the shared Flight SYNCHRONOUSLY (before any await) so a
+        // concurrent RemoveAsync deterministically observes an in-flight creation and can invalidate it.
+        // The caller that installed it runs the read+factory DETACHED (so its own cancellation doesn't
+        // block the shared work); every caller — winner and losers alike — awaits the shared task via
+        // WaitAsync, observing per-caller cancellation. The read (hit / cross-process / sliding refresh)
+        // happens inside the winner's CreateAsync, so a hit still avoids invoking the factory.
         var tcs = new TaskCompletionSource<TValue>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var task = _inflight.GetOrAdd(k, tcs.Task);
-        if (task == tcs.Task)
+        var flight = new Flight { Task = tcs.Task };
+        var existing = _inflight.GetOrAdd(k, flight);
+        if (existing == flight)
         {
-            try
-            {
-                tcs.TrySetResult(await CreateAsync(k, key, factory, context, options));
-            }
-            catch (Exception ex)
-            {
-                this.Trace("Factory failed for {key}", key);
-                this.Error(ex);
-                tcs.TrySetException(ex);
-            }
-            finally
-            {
-                // unpoison: the shared task is settled, so a later call re-reads / re-creates
-                _inflight.TryRemove(new KeyValuePair<string, Task<TValue>>(k, tcs.Task));
-            }
+            // fire-and-forget: RunFactoryAsync always settles the tcs, so no exception is unobserved.
+            _ = RunFactoryAsync(k, key, factory, context, options, flight, tcs);
         }
 
-        // VSTHRD003: `task` is this cache's own single-flight task (installed above), not a foreign one.
+        // VSTHRD003: the shared task is this cache's own single-flight task, not a foreign one.
 #pragma warning disable VSTHRD003
-        return await task.WaitAsync(ct);
+        return await existing.Task.WaitAsync(ct);
 #pragma warning restore VSTHRD003
+    }
+
+    /// <summary>
+    /// Runs the factory for the single-flight winner detached from any caller, always settling the shared
+    /// task and unpoisoning the in-flight slot so a later call re-reads / re-creates.
+    /// </summary>
+    private async Task RunFactoryAsync<TContext>(
+        string k,
+        TKey key,
+        Func<TKey, TContext, CancellationToken, ValueTask<TValue>> factory,
+        TContext context,
+        CacheOptions options,
+        Flight flight,
+        TaskCompletionSource<TValue> tcs
+    )
+        where TContext : notnull
+    {
+        try
+        {
+            tcs.TrySetResult(await CreateAsync(k, key, factory, context, options, flight));
+        }
+        catch (Exception ex)
+        {
+            this.Trace("Factory failed for {key}", key);
+            this.Error(ex);
+            tcs.TrySetException(ex);
+        }
+        finally
+        {
+            _inflight.TryRemove(new KeyValuePair<string, Flight>(k, flight));
+        }
     }
 
     /// <summary>
@@ -157,7 +175,14 @@ internal class Cache<TKey, TValue> : ICache<TKey, TValue>, ILogSubject
         ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
         ct.ThrowIfCancellationRequested();
 
-        await _storage.DeleteAsync(Key(key), ct);
+        var k = Key(key);
+
+        // invalidate any in-flight creation for this key so its (post-factory) write is suppressed —
+        // a remove during creation must purge the entry, not race a stale write back in.
+        if (_inflight.TryGetValue(k, out var flight))
+            flight.Invalidated = true;
+
+        await _storage.DeleteAsync(k, ct);
     }
 
     /// <summary>
@@ -211,17 +236,24 @@ internal class Cache<TKey, TValue> : ICache<TKey, TValue>, ILogSubject
         TKey key,
         Func<TKey, TContext, CancellationToken, ValueTask<TValue>> factory,
         TContext context,
-        CacheOptions options
+        CacheOptions options,
+        Flight flight
     )
         where TContext : notnull
     {
-        // double-check: another process may have written between our fast-path read and here
+        // read: return a live stored value (own earlier write, a cross-process write, or a sliding hit
+        // which ReadLiveAsync also refreshes) without invoking the factory.
         var (hit, value) = await ReadLiveAsync(k, CancellationToken.None);
         if (hit)
             return value;
 
         this.Trace("Create item for {key}", key);
         value = await factory(key, context, CancellationToken.None);
+
+        // A RemoveAsync that ran while the factory was in flight invalidated this creation — return the
+        // produced value to the awaiting callers but do NOT write it back, so the key stays purged.
+        if (flight.Invalidated)
+            return value;
 
         var now = _timeProvider.Now;
         var expiresAt = options.GetExpiresAt(now);
@@ -240,7 +272,29 @@ internal class Cache<TKey, TValue> : ICache<TKey, TValue>, ILogSubject
 
         await _storage.SetAsync(k, _serializer.Serialize(envelope), ttl, CancellationToken.None);
 
+        // a RemoveAsync that landed during the write (after the pre-write check above, before the SET
+        // completed) must still win — delete the just-written entry so a concurrent remove is not lost.
+        if (flight.Invalidated)
+            await _storage.DeleteAsync(k, CancellationToken.None);
+
         return value;
+    }
+
+    /// <summary>
+    /// A single in-flight factory run for a key. Carries the shared task all callers await, plus an
+    /// invalidation flag set by <see cref="RemoveAsync"/> to suppress a post-factory write-back.
+    /// </summary>
+    private sealed class Flight
+    {
+        /// <summary>
+        /// Gets the shared task that resolves to the created value (or faults with the factory's exception).
+        /// </summary>
+        public required Task<TValue> Task { get; init; }
+
+        /// <summary>
+        /// Whether a concurrent remove invalidated this creation; when set, the winner skips the write-back.
+        /// </summary>
+        public volatile bool Invalidated;
     }
 
     /// <summary>

--- a/base/Cache/src/Annium.Cache.Redis/Internal/Cache.cs
+++ b/base/Cache/src/Annium.Cache.Redis/Internal/Cache.cs
@@ -185,8 +185,19 @@ internal class Cache<TKey, TValue> : ICache<TKey, TValue>, ILogSubject
             return (false, default!);
 
         var env = _serializer.Deserialize<CacheEnvelope<TValue>>(raw);
-        if (_timeProvider.Now.ToUnixTimeMilliseconds() >= env.ExpiresAtMs)
+        var now = _timeProvider.Now;
+        if (now.ToUnixTimeMilliseconds() >= env.ExpiresAtMs)
             return (false, default!);
+
+        // sliding refresh: prolong the window on access using the STORED lifetime (first-writer-wins —
+        // a later caller's options must not change the entry's strategy). No atomic GETEX on IRedisStorage,
+        // so this is a GET (above) + SET (2 RTT); a benign race between concurrent readers prolongs alike.
+        if (env.Mode == CacheExpirationMode.Sliding && env.LifetimeMs is { } lifetimeMs)
+        {
+            var lifetime = Duration.FromMilliseconds(lifetimeMs);
+            var refreshed = env with { ExpiresAtMs = (now + lifetime).ToUnixTimeMilliseconds() };
+            await _storage.SetAsync(k, _serializer.Serialize(refreshed), lifetime, ct);
+        }
 
         return (true, env.Value);
     }

--- a/base/Cache/src/Annium.Cache.Redis/Internal/Cache.cs
+++ b/base/Cache/src/Annium.Cache.Redis/Internal/Cache.cs
@@ -107,8 +107,7 @@ internal class Cache<TKey, TValue> : ICache<TKey, TValue>, ILogSubject
     )
         where TContext : notnull
     {
-        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
-        ct.ThrowIfCancellationRequested();
+        EnsureUsable(ct);
 
         var k = Key(key);
 
@@ -181,8 +180,7 @@ internal class Cache<TKey, TValue> : ICache<TKey, TValue>, ILogSubject
     /// <returns>A value task that represents the asynchronous remove operation.</returns>
     public async ValueTask RemoveAsync(TKey key, CancellationToken ct = default)
     {
-        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
-        ct.ThrowIfCancellationRequested();
+        EnsureUsable(ct);
 
         var k = Key(key);
 
@@ -208,11 +206,15 @@ internal class Cache<TKey, TValue> : ICache<TKey, TValue>, ILogSubject
 
     /// <summary>
     /// Reads the stored entry for a key and returns it only if it is logically live (not past its deadline).
+    /// On a sliding hit it prolongs the entry; if a concurrent <see cref="RemoveAsync"/> invalidated this
+    /// in-flight creation while the prolongation write was in flight, the refreshed entry is compensating-deleted
+    /// so the remove still wins (symmetric with the post-write guard in <see cref="CreateAsync"/>).
     /// </summary>
     /// <param name="k">The prefixed Redis key.</param>
+    /// <param name="flight">The in-flight holder; its invalidation flag suppresses a sliding-refresh resurrection after a concurrent remove.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>A tuple of (hit, value); <c>hit</c> is false on a missing or logically-expired entry.</returns>
-    private async Task<(bool Hit, TValue Value)> ReadLiveAsync(string k, CancellationToken ct)
+    private async Task<(bool Hit, TValue Value)> ReadLiveAsync(string k, Flight flight, CancellationToken ct)
     {
         var raw = await _storage.GetAsync(k, ct);
         if (raw is null)
@@ -231,6 +233,11 @@ internal class Cache<TKey, TValue> : ICache<TKey, TValue>, ILogSubject
             var lifetime = Duration.FromMilliseconds(lifetimeMs);
             var refreshed = env with { ExpiresAtMs = (now + lifetime).ToUnixTimeMilliseconds() };
             await _storage.SetAsync(k, _serializer.Serialize(refreshed), lifetime, ct);
+
+            // a RemoveAsync that landed during the refresh (after the GET above, before the SET completed)
+            // invalidated this creation — delete the just-refreshed entry so the remove is not resurrected.
+            if (flight.Invalidated)
+                await _storage.DeleteAsync(k, ct);
         }
 
         return (true, env.Value);
@@ -260,7 +267,7 @@ internal class Cache<TKey, TValue> : ICache<TKey, TValue>, ILogSubject
     {
         // read: return a live stored value (own earlier write, a cross-process write, or a sliding hit
         // which ReadLiveAsync also refreshes) without invoking the factory.
-        var (hit, value) = await ReadLiveAsync(k, CancellationToken.None);
+        var (hit, value) = await ReadLiveAsync(k, flight, CancellationToken.None);
         if (hit)
             return value;
 
@@ -315,9 +322,28 @@ internal class Cache<TKey, TValue> : ICache<TKey, TValue>, ILogSubject
     }
 
     /// <summary>
-    /// Builds the namespaced Redis key for a cache key by prepending the configured prefix.
+    /// Throws if the cache is disposed or the caller's token is already cancelled.
+    /// </summary>
+    /// <param name="ct">The caller's cancellation token.</param>
+    private void EnsureUsable(CancellationToken ct)
+    {
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+        ct.ThrowIfCancellationRequested();
+    }
+
+    /// <summary>
+    /// Per-value-type discriminator folded into every Redis key. Distinct <see cref="Cache{TKey,TValue}"/>
+    /// closed generics resolved from one registration share a single <see cref="RedisCacheOptions"/> and one
+    /// Redis instance; unlike InMemory (which isolates by instance), Redis has a single shared store, so the
+    /// value type must be part of the key — otherwise e.g. <c>ICache&lt;Guid,User&gt;</c> and
+    /// <c>ICache&lt;Guid,Order&gt;</c> would collide on identical keys.
+    /// </summary>
+    private static readonly string _typeDiscriminator = (typeof(TValue).FullName ?? typeof(TValue).Name) + ":";
+
+    /// <summary>
+    /// Builds the namespaced Redis key: configured prefix + value-type discriminator + the cache key.
     /// </summary>
     /// <param name="key">The cache key.</param>
-    /// <returns>The prefixed Redis key string.</returns>
-    private string Key(TKey key) => _options.KeyPrefix + key;
+    /// <returns>The prefixed, value-type-scoped Redis key string.</returns>
+    private string Key(TKey key) => _options.KeyPrefix + _typeDiscriminator + key;
 }

--- a/base/Cache/src/Annium.Cache.Redis/Internal/Cache.cs
+++ b/base/Cache/src/Annium.Cache.Redis/Internal/Cache.cs
@@ -137,6 +137,15 @@ internal class Cache<TKey, TValue> : ICache<TKey, TValue>, ILogSubject
     /// Runs the factory for the single-flight winner detached from any caller, always settling the shared
     /// task and unpoisoning the in-flight slot so a later call re-reads / re-creates.
     /// </summary>
+    /// <typeparam name="TContext">The type of the context object passed to the factory.</typeparam>
+    /// <param name="k">The prefixed Redis key.</param>
+    /// <param name="key">The cache key.</param>
+    /// <param name="factory">Factory function to create the value.</param>
+    /// <param name="context">Context object passed to the factory function.</param>
+    /// <param name="options">Cache options including expiration settings.</param>
+    /// <param name="flight">The in-flight holder for this key (carries the shared task and the invalidation flag).</param>
+    /// <param name="tcs">The task completion source that all callers await.</param>
+    /// <returns>A task that completes when the factory run has settled the shared task.</returns>
     private async Task RunFactoryAsync<TContext>(
         string k,
         TKey key,
@@ -231,6 +240,14 @@ internal class Cache<TKey, TValue> : ICache<TKey, TValue>, ILogSubject
     /// The single-flight winner's work: re-check the store, invoke the factory, and write the value with
     /// its expiry envelope. The factory runs detached from any single caller's cancellation.
     /// </summary>
+    /// <typeparam name="TContext">The type of the context object passed to the factory.</typeparam>
+    /// <param name="k">The prefixed Redis key.</param>
+    /// <param name="key">The cache key.</param>
+    /// <param name="factory">Factory function to create the value.</param>
+    /// <param name="context">Context object passed to the factory function.</param>
+    /// <param name="options">Cache options including expiration settings.</param>
+    /// <param name="flight">The in-flight holder; its invalidation flag suppresses the write-back after a concurrent remove.</param>
+    /// <returns>A task that resolves to the cached or newly created value.</returns>
     private async Task<TValue> CreateAsync<TContext>(
         string k,
         TKey key,

--- a/base/Cache/src/Annium.Cache.Redis/Internal/CacheEnvelope.cs
+++ b/base/Cache/src/Annium.Cache.Redis/Internal/CacheEnvelope.cs
@@ -1,0 +1,32 @@
+using Annium.Cache.Abstractions;
+
+namespace Annium.Cache.Redis.Internal;
+
+/// <summary>
+/// Serialized cache entry stored in Redis: the value plus the expiration metadata needed to enforce
+/// logical expiry (via <c>ITimeProvider</c>) independently of Redis' physical TTL.
+/// </summary>
+/// <typeparam name="TValue">The type of the cached value.</typeparam>
+internal sealed record CacheEnvelope<TValue>
+{
+    /// <summary>
+    /// Gets the cached value.
+    /// </summary>
+    public TValue Value { get; init; } = default!;
+
+    /// <summary>
+    /// Gets the expiration mode this entry was created with.
+    /// </summary>
+    public CacheExpirationMode Mode { get; init; }
+
+    /// <summary>
+    /// Gets the absolute expiration deadline as Unix epoch milliseconds (computed from the cache's time provider).
+    /// </summary>
+    public long ExpiresAtMs { get; init; }
+
+    /// <summary>
+    /// Gets the sliding lifetime in milliseconds, or <see langword="null"/> for absolute expiration. Used to
+    /// prolong the entry on each access (sliding refresh).
+    /// </summary>
+    public long? LifetimeMs { get; init; }
+}

--- a/base/Cache/src/Annium.Cache.Redis/RedisCacheOptions.cs
+++ b/base/Cache/src/Annium.Cache.Redis/RedisCacheOptions.cs
@@ -1,0 +1,14 @@
+namespace Annium.Cache.Redis;
+
+/// <summary>
+/// Options for the Redis-backed cache. Connection settings are owned by <c>Annium.Redis</c>
+/// (registered via <c>AddRedis</c>); these options cover cache-level concerns only.
+/// </summary>
+public record RedisCacheOptions
+{
+    /// <summary>
+    /// Gets or sets the prefix prepended to every cache key, namespacing entries so that the cache
+    /// can share a Redis instance with other <c>IRedisStorage</c> consumers without key collisions.
+    /// </summary>
+    public string KeyPrefix { get; set; } = string.Empty;
+}

--- a/base/Cache/src/Annium.Cache.Redis/ServiceContainerExtensions.cs
+++ b/base/Cache/src/Annium.Cache.Redis/ServiceContainerExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using Annium.Cache.Abstractions;
 using Annium.Cache.Redis.Internal;
 using Annium.Core.DependencyInjection;
@@ -5,18 +6,29 @@ using Annium.Core.DependencyInjection;
 namespace Annium.Cache.Redis;
 
 /// <summary>
-/// Extension methods for registering Redis cache services
+/// Extension methods for registering the Redis cache implementation.
 /// </summary>
 public static class ServiceContainerExtensions
 {
     /// <summary>
-    /// Registers Redis cache implementation in the service container
+    /// Registers the Redis cache implementation in the service container. The underlying Redis
+    /// connection is expected to be registered separately via <c>AddRedis</c> (an
+    /// <c>IRedisStorage</c> singleton).
     /// </summary>
-    /// <param name="container">The service container</param>
-    /// <param name="lifetime">The service lifetime for cache instances</param>
-    /// <returns>The service container for chaining</returns>
-    public static IServiceContainer AddRedisCache(this IServiceContainer container, ServiceLifetime lifetime)
+    /// <param name="container">The service container.</param>
+    /// <param name="configure">Optional callback to configure <see cref="RedisCacheOptions"/> (e.g. the key prefix).</param>
+    /// <param name="lifetime">The service lifetime for cache instances.</param>
+    /// <returns>The service container for chaining.</returns>
+    public static IServiceContainer AddRedisCache(
+        this IServiceContainer container,
+        Action<RedisCacheOptions>? configure = null,
+        ServiceLifetime lifetime = ServiceLifetime.Singleton
+    )
     {
+        var options = new RedisCacheOptions();
+        configure?.Invoke(options);
+        container.Add(options).AsSelf().Singleton();
+
         container.Add(typeof(Cache<,>)).As(typeof(ICache<,>)).In(lifetime);
 
         return container;

--- a/base/Cache/tests/Annium.Cache.InMemory.Tests/CacheTests.cs
+++ b/base/Cache/tests/Annium.Cache.InMemory.Tests/CacheTests.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Annium.Cache.Tests.Lib;
+using Annium.Testing;
 using Xunit;
 
 namespace Annium.Cache.InMemory.Tests;
@@ -18,6 +19,14 @@ public class CacheTests : CacheTestsBase
     {
         RegisterServicePack<ServicePack>();
     }
+
+    /// <summary>
+    /// InMemory contract: one shared instance per key — assert strict reference identity.
+    /// </summary>
+    /// <typeparam name="T">The reference type of the cached items.</typeparam>
+    /// <param name="actual">The item under test.</param>
+    /// <param name="expected">The reference item to compare against.</param>
+    protected override void AssertCachedInstance<T>(T actual, T expected) => ReferenceEquals(actual, expected).IsTrue();
 
     /// <summary>
     /// Tests the default behavior of GetOrCreateAsync for the in-memory cache implementation.

--- a/base/Cache/tests/Annium.Cache.Redis.Tests/Annium.Cache.Redis.Tests.csproj
+++ b/base/Cache/tests/Annium.Cache.Redis.Tests/Annium.Cache.Redis.Tests.csproj
@@ -5,11 +5,12 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <ThreadPoolMinThreads>256</ThreadPoolMinThreads>
   </PropertyGroup>
   <ItemGroup>
+    <ProjectReference Include="../../../../integrations/Redis/src/Annium.Redis/Annium.Redis.csproj" />
     <ProjectReference Include="../../src/Annium.Cache.Redis/Annium.Cache.Redis.csproj" />
     <ProjectReference Include="../Annium.Cache.Tests.Lib/Annium.Cache.Tests.Lib.csproj" />
-    <ProjectReference Include="../../../../integrations/Redis/src/Annium.Redis/Annium.Redis.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Annium.Serialization.Json" />

--- a/base/Cache/tests/Annium.Cache.Redis.Tests/Annium.Cache.Redis.Tests.csproj
+++ b/base/Cache/tests/Annium.Cache.Redis.Tests/Annium.Cache.Redis.Tests.csproj
@@ -9,10 +9,14 @@
   <ItemGroup>
     <ProjectReference Include="../../src/Annium.Cache.Redis/Annium.Cache.Redis.csproj" />
     <ProjectReference Include="../Annium.Cache.Tests.Lib/Annium.Cache.Tests.Lib.csproj" />
+    <ProjectReference Include="../../../../integrations/Redis/src/Annium.Redis/Annium.Redis.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Annium.Serialization.Json" />
+    <PackageReference Include="Annium.Testing" />
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Testcontainers.Redis" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="xunit.v3" />
   </ItemGroup>

--- a/base/Cache/tests/Annium.Cache.Redis.Tests/CacheTests.cs
+++ b/base/Cache/tests/Annium.Cache.Redis.Tests/CacheTests.cs
@@ -186,15 +186,37 @@ public class CacheTests : CacheTestsBase
         await GetOrCreateAsync_ConcurrentDistinctKeys_EachFactoryOnce_Base();
     }
 
-    // ── Deferred: Sliding + FirstWriterWins (Task 4); poison/cancel/drain (Task 5) ───────
+    // ── Sliding + FirstWriterWins (Task 4) ──────────────────────────────────────────────
 
     /// <summary>
-    /// Tests GetOrCreateAsync with sliding expiration (prolongation on access) — implemented in Task 4.
+    /// Tests GetOrCreateAsync with sliding expiration (recreated after the window elapses without access).
     /// </summary>
     /// <returns>A task that represents the asynchronous test operation</returns>
-    [Fact(Skip = "sliding refresh — Task 4")]
+    [Fact]
     public async Task GetOrCreateAsync_SlidingExpiration()
     {
         await GetOrCreateAsync_SlidingExpiration_Base();
     }
+
+    /// <summary>
+    /// Verifies sliding expiration is prolonged on each hit so an accessed entry survives its original window.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation</returns>
+    [Fact]
+    public async Task GetOrCreateAsync_SlidingExpiration_AccessWithinWindowProlongs()
+    {
+        await GetOrCreateAsync_SlidingExpiration_AccessWithinWindowProlongs_Base();
+    }
+
+    /// <summary>
+    /// Verifies first-writer-wins: a later caller's different (shorter) options are ignored for a live key.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation</returns>
+    [Fact]
+    public async Task GetOrCreateAsync_FirstWriterWins_LaterCallerOptionsIgnored()
+    {
+        await GetOrCreateAsync_FirstWriterWins_LaterCallerOptionsIgnored_Base();
+    }
+
+    // ── Deferred: poison/cancel/drain in-flight grани (Task 5) ───────────────────────────
 }

--- a/base/Cache/tests/Annium.Cache.Redis.Tests/CacheTests.cs
+++ b/base/Cache/tests/Annium.Cache.Redis.Tests/CacheTests.cs
@@ -218,5 +218,55 @@ public class CacheTests : CacheTestsBase
         await GetOrCreateAsync_FirstWriterWins_LaterCallerOptionsIgnored_Base();
     }
 
-    // ── Deferred: poison/cancel/drain in-flight grани (Task 5) ───────────────────────────
+    // ── Single-flight edges: poison / cancel / drain (Task 5) ────────────────────────────
+
+    /// <summary>
+    /// Verifies a factory exception surfaces to the awaiting caller and the slot is unpoisoned.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation</returns>
+    [Fact]
+    public async Task GetOrCreateAsync_FactoryThrows_PropagatesAndUnpoisons()
+    {
+        await GetOrCreateAsync_FactoryThrows_PropagatesAndUnpoisons_Base();
+    }
+
+    /// <summary>
+    /// Verifies all concurrent callers observe the deduplicated factory exception (no hang).
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation</returns>
+    [Fact]
+    public async Task GetOrCreateAsync_FactoryThrows_ConcurrentCallersAllSeeException()
+    {
+        await GetOrCreateAsync_FactoryThrows_ConcurrentCallersAllSeeException_Base();
+    }
+
+    /// <summary>
+    /// Verifies one caller's cancellation does not fault the shared task for other awaiters.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation</returns>
+    [Fact]
+    public async Task GetOrCreateAsync_CancelDuringFactory_OneAwaiterCancelsOthersContinue()
+    {
+        await GetOrCreateAsync_CancelDuringFactory_OneAwaiterCancelsOthersContinue_Base();
+    }
+
+    /// <summary>
+    /// Verifies RemoveAsync during an in-flight factory delivers the value then re-invokes on the next call.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation</returns>
+    [Fact]
+    public async Task RemoveAsync_WhileFactoryInFlight_CallerGetsValueThenReinvokes()
+    {
+        await RemoveAsync_WhileFactoryInFlight_CallerGetsValueThenReinvokes_Base();
+    }
+
+    /// <summary>
+    /// Verifies disposing while a factory is in-flight drains cleanly and the caller still completes.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation</returns>
+    [Fact]
+    public async Task DisposeAsync_WhileFactoryInFlight_DrainsAndCallerCompletes()
+    {
+        await DisposeAsync_WhileFactoryInFlight_DrainsAndCallerCompletes_Base();
+    }
 }

--- a/base/Cache/tests/Annium.Cache.Redis.Tests/CacheTests.cs
+++ b/base/Cache/tests/Annium.Cache.Redis.Tests/CacheTests.cs
@@ -24,6 +24,8 @@ public class CacheTests : CacheTestsBase
         RegisterServicePack<ServicePack>();
     }
 
+    // ── Redis-specific harness / white-box ──────────────────────────────────────────────
+
     /// <summary>
     /// Verifies the DI/test harness: the Testcontainers Redis backend starts, the cache and the shared
     /// <see cref="IRedisStorage"/> resolve, the cache options are registered, and the backend is reachable
@@ -35,14 +37,11 @@ public class CacheTests : CacheTestsBase
     {
         var ct = TestContext.Current.CancellationToken;
 
-        // cache resolves from the open-generic registration
         var cache = Get<ICache<Guid, string>>();
         cache.IsNotNull();
 
-        // cache options are registered with the configured prefix
         Get<RedisCacheOptions>().KeyPrefix.Is("test:");
 
-        // the shared storage is reachable end-to-end (round-trip against the started container)
         var storage = Get<IRedisStorage>();
         var key = Guid.NewGuid().ToString();
         await storage.SetAsync(key, "v", ct: ct);
@@ -62,14 +61,11 @@ public class CacheTests : CacheTestsBase
         var key = Guid.NewGuid();
         var prefixed = $"test:{key}";
 
-        // seed the prefixed entry directly via storage
         await storage.SetAsync(prefixed, "v", ct: ct);
         (await storage.GetAsync(prefixed, ct)).IsNotDefault();
 
-        // act
         await cache.RemoveAsync(key, ct);
 
-        // assert: the prefixed key was deleted
         (await storage.GetAsync(prefixed, ct)).IsDefault();
     }
 
@@ -88,43 +84,117 @@ public class CacheTests : CacheTestsBase
         provider.Resolve<RedisCacheOptions>().KeyPrefix.Is("t:");
     }
 
+    // ── Shared contract scenarios (Task 3: core + Absolute + single-flight) ──────────────
+
     /// <summary>
-    /// Tests the default behavior of GetOrCreateAsync for the Redis cache implementation.
+    /// Tests the default behavior of GetOrCreateAsync (concurrent callers share one factory run, value-equal).
     /// </summary>
     /// <returns>A task that represents the asynchronous test operation</returns>
-    [Fact(Skip = "not implemented")]
+    [Fact]
     public async Task GetOrCreateAsync_Default()
     {
         await GetOrCreateAsync_Default_Base();
     }
 
     /// <summary>
-    /// Tests GetOrCreateAsync with absolute expiration for the Redis cache implementation.
+    /// Tests GetOrCreateAsync with absolute expiration (logical expiry drives re-creation after managed time advances).
     /// </summary>
     /// <returns>A task that represents the asynchronous test operation</returns>
-    [Fact(Skip = "not implemented")]
+    [Fact]
     public async Task GetOrCreateAsync_AbsoluteExpiration()
     {
         await GetOrCreateAsync_AbsoluteExpiration_Base();
     }
 
     /// <summary>
-    /// Tests GetOrCreateAsync with sliding expiration for the Redis cache implementation.
+    /// Tests the RemoveAsync functionality (remove → next GetOrCreate re-invokes the factory).
     /// </summary>
     /// <returns>A task that represents the asynchronous test operation</returns>
-    [Fact(Skip = "not implemented")]
-    public async Task GetOrCreateAsync_SlidingExpiration()
-    {
-        await GetOrCreateAsync_SlidingExpiration_Base();
-    }
-
-    /// <summary>
-    /// Tests the RemoveAsync functionality for the Redis cache implementation.
-    /// </summary>
-    /// <returns>A task that represents the asynchronous test operation</returns>
-    [Fact(Skip = "not implemented")]
+    [Fact]
     public async Task RemoveAsync()
     {
         await RemoveAsync_Base();
+    }
+
+    /// <summary>
+    /// Verifies removing a non-existent key is a silent no-op.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation</returns>
+    [Fact]
+    public async Task RemoveAsync_NonExistentKey_CompletesWithoutException()
+    {
+        await RemoveAsync_NonExistentKey_CompletesWithoutException_Base();
+    }
+
+    /// <summary>
+    /// Verifies the context-carrying GetOrCreateAsync overload forwards the supplied context to the factory.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation</returns>
+    [Fact]
+    public async Task GetOrCreateAsync_WithContext_ContextPassedToFactory()
+    {
+        await GetOrCreateAsync_WithContext_ContextPassedToFactory_Base();
+    }
+
+    /// <summary>
+    /// Verifies cache operations on a disposed cache throw instead of hanging.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation</returns>
+    [Fact]
+    public async Task GetOrCreateAsync_AfterDispose_Throws()
+    {
+        await GetOrCreateAsync_AfterDispose_Throws_Base();
+    }
+
+    /// <summary>
+    /// Verifies a pre-cancelled CT is observed before the factory is invoked.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation</returns>
+    [Fact]
+    public async Task GetOrCreateAsync_PreCancelledCt_ThrowsBeforeFactoryCall()
+    {
+        await GetOrCreateAsync_PreCancelledCt_ThrowsBeforeFactoryCall_Base();
+    }
+
+    /// <summary>
+    /// Verifies RemoveAsync observes a pre-cancelled CT.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation</returns>
+    [Fact]
+    public async Task RemoveAsync_PreCancelledCt_Throws()
+    {
+        await RemoveAsync_PreCancelledCt_Throws_Base();
+    }
+
+    /// <summary>
+    /// Verifies DisposeAsync is idempotent.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation</returns>
+    [Fact]
+    public async Task DisposeAsync_CalledTwice_DoesNotThrow()
+    {
+        await DisposeAsync_CalledTwice_DoesNotThrow_Base();
+    }
+
+    /// <summary>
+    /// Verifies concurrent access across many distinct keys runs each key's factory exactly once.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation</returns>
+    [Fact]
+    public async Task GetOrCreateAsync_ConcurrentDistinctKeys_EachFactoryOnce()
+    {
+        await GetOrCreateAsync_ConcurrentDistinctKeys_EachFactoryOnce_Base();
+    }
+
+    // ── Deferred: Sliding + FirstWriterWins (Task 4); poison/cancel/drain (Task 5) ───────
+
+    /// <summary>
+    /// Tests GetOrCreateAsync with sliding expiration (prolongation on access) — implemented in Task 4.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation</returns>
+    [Fact(Skip = "sliding refresh — Task 4")]
+    public async Task GetOrCreateAsync_SlidingExpiration()
+    {
+        await GetOrCreateAsync_SlidingExpiration_Base();
     }
 }

--- a/base/Cache/tests/Annium.Cache.Redis.Tests/CacheTests.cs
+++ b/base/Cache/tests/Annium.Cache.Redis.Tests/CacheTests.cs
@@ -59,7 +59,7 @@ public class CacheTests : CacheTestsBase
         var cache = Get<ICache<Guid, string>>();
         var storage = Get<IRedisStorage>();
         var key = Guid.NewGuid();
-        var prefixed = $"test:{key}";
+        var prefixed = RedisTestKeys.Prefixed<string>(key);
 
         await storage.SetAsync(prefixed, "v", ct: ct);
         (await storage.GetAsync(prefixed, ct)).IsNotDefault();

--- a/base/Cache/tests/Annium.Cache.Redis.Tests/CacheTests.cs
+++ b/base/Cache/tests/Annium.Cache.Redis.Tests/CacheTests.cs
@@ -1,5 +1,10 @@
+using System;
 using System.Threading.Tasks;
+using Annium.Cache.Abstractions;
 using Annium.Cache.Tests.Lib;
+using Annium.Core.DependencyInjection;
+using Annium.Redis;
+using Annium.Testing;
 using Xunit;
 
 namespace Annium.Cache.Redis.Tests;
@@ -17,6 +22,70 @@ public class CacheTests : CacheTestsBase
         : base(outputHelper)
     {
         RegisterServicePack<ServicePack>();
+    }
+
+    /// <summary>
+    /// Verifies the DI/test harness: the Testcontainers Redis backend starts, the cache and the shared
+    /// <see cref="IRedisStorage"/> resolve, the cache options are registered, and the backend is reachable
+    /// (a storage round-trip succeeds).
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task Resolves_CacheAndContainerStarts()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // cache resolves from the open-generic registration
+        var cache = Get<ICache<Guid, string>>();
+        cache.IsNotNull();
+
+        // cache options are registered with the configured prefix
+        Get<RedisCacheOptions>().KeyPrefix.Is("test:");
+
+        // the shared storage is reachable end-to-end (round-trip against the started container)
+        var storage = Get<IRedisStorage>();
+        var key = Guid.NewGuid().ToString();
+        await storage.SetAsync(key, "v", ct: ct);
+        (await storage.GetAsync(key, ct)).Is("v");
+    }
+
+    /// <summary>
+    /// Verifies <see cref="ICache{TKey,TValue}.RemoveAsync"/> deletes the prefixed key via the shared storage.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task RemoveAsync_DeletesPrefixedKeyViaStorage()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var cache = Get<ICache<Guid, string>>();
+        var storage = Get<IRedisStorage>();
+        var key = Guid.NewGuid();
+        var prefixed = $"test:{key}";
+
+        // seed the prefixed entry directly via storage
+        await storage.SetAsync(prefixed, "v", ct: ct);
+        (await storage.GetAsync(prefixed, ct)).IsNotDefault();
+
+        // act
+        await cache.RemoveAsync(key, ct);
+
+        // assert: the prefixed key was deleted
+        (await storage.GetAsync(prefixed, ct)).IsDefault();
+    }
+
+    /// <summary>
+    /// Verifies the configure overload of <c>AddRedisCache</c> builds and registers
+    /// <see cref="RedisCacheOptions"/> with the supplied prefix (DI-only, no container).
+    /// </summary>
+    [Fact]
+    public void AddRedisCache_ConfigureOverload_RegistersOptions()
+    {
+        var container = new ServiceContainer();
+        container.AddRedisCache(cfg => cfg.KeyPrefix = "t:");
+
+        var provider = container.BuildServiceProvider();
+
+        provider.Resolve<RedisCacheOptions>().KeyPrefix.Is("t:");
     }
 
     /// <summary>

--- a/base/Cache/tests/Annium.Cache.Redis.Tests/Database.cs
+++ b/base/Cache/tests/Annium.Cache.Redis.Tests/Database.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Threading.Tasks;
+using Annium.Redis;
+using Testcontainers.Redis;
+
+namespace Annium.Cache.Redis.Tests;
+
+/// <summary>
+/// Test database setup for Redis cache integration tests using Testcontainers. Implements
+/// <see cref="IAsyncDisposable"/> so the started container is stopped and removed when the
+/// owning test provider is torn down, rather than lingering until the Ryuk reaper at process exit.
+/// </summary>
+public class Database : IAsyncDisposable
+{
+    /// <summary>
+    /// Gets the Redis connection configuration (consumed by <c>AddRedis</c> / <c>IRedisStorage</c>).
+    /// </summary>
+    public Annium.Redis.RedisConfiguration Config { get; } = new();
+
+    /// <summary>
+    /// Redis container instance for testing.
+    /// </summary>
+    private readonly RedisContainer _db;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Database"/> class with Redis container configuration.
+    /// </summary>
+    public Database()
+    {
+        _db = new RedisBuilder("redis:7-alpine").Build();
+    }
+
+    /// <summary>
+    /// Initializes the Redis test database by starting the container and configuring the connection.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous initialization operation.</returns>
+    public async Task InitAsync()
+    {
+        await _db.StartAsync();
+        Config.Hosts = [new RedisHost(_db.Hostname, _db.GetMappedPublicPort(RedisBuilder.RedisPort))];
+    }
+
+    /// <summary>
+    /// Stops and removes the Redis test container.
+    /// </summary>
+    /// <returns>A value task that completes when the container has been disposed.</returns>
+    public async ValueTask DisposeAsync()
+    {
+        GC.SuppressFinalize(this);
+        await _db.DisposeAsync();
+    }
+}

--- a/base/Cache/tests/Annium.Cache.Redis.Tests/FakeStorageServicePack.cs
+++ b/base/Cache/tests/Annium.Cache.Redis.Tests/FakeStorageServicePack.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Annium.Core.DependencyInjection;
+using Annium.Redis;
+using Annium.Serialization.Abstractions;
+using Annium.Serialization.Json;
+
+namespace Annium.Cache.Redis.Tests;
+
+/// <summary>
+/// Service pack wiring the Redis cache over an in-process <see cref="GatedRedisStorage"/> instead of a real
+/// Testcontainers backend, so storage-timing races (sliding-refresh vs remove, post-write invalidation) can be
+/// interleaved deterministically.
+/// </summary>
+public class FakeStorageServicePack : ServicePackBase
+{
+    /// <summary>
+    /// Registers a JSON serializer, the gated in-memory storage (as <see cref="IRedisStorage"/>), and the cache.
+    /// </summary>
+    /// <param name="container">The service container to register services with.</param>
+    /// <param name="provider">The service provider for resolving dependencies.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A task that represents the asynchronous registration.</returns>
+    public override Task RegisterAsync(IServiceContainer container, IServiceProvider provider, CancellationToken ct)
+    {
+        container.AddSerializers().WithJson(isDefault: true);
+        container.Add<IRedisStorage, GatedRedisStorage>().Singleton();
+        container.AddRedisCache(cfg => cfg.KeyPrefix = "test:");
+        return Task.CompletedTask;
+    }
+}

--- a/base/Cache/tests/Annium.Cache.Redis.Tests/GatedRedisStorage.cs
+++ b/base/Cache/tests/Annium.Cache.Redis.Tests/GatedRedisStorage.cs
@@ -1,0 +1,122 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Annium.Redis;
+using NodaTime;
+
+namespace Annium.Cache.Redis.Tests;
+
+/// <summary>
+/// In-memory <see cref="IRedisStorage"/> test double with a one-shot gate on <see cref="SetAsync"/>, used to
+/// deterministically interleave a concurrent <c>RemoveAsync</c> with an in-flight cache write. Physical expiry
+/// (<c>expires</c>) is ignored — the cache under test drives expiry logically via <c>ITimeProvider</c>.
+/// </summary>
+internal sealed class GatedRedisStorage : IRedisStorage
+{
+    /// <summary>
+    /// In-memory backing store (key → serialized value). Physical TTL is not modelled.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, string> _data = new();
+
+    /// <summary>
+    /// One-shot gate signal, completed when a gated <see cref="SetAsync"/> enters and pauses; null when disarmed.
+    /// </summary>
+    private TaskCompletionSource? _setEntered;
+
+    /// <summary>
+    /// One-shot gate release, completed by <see cref="ReleaseSet"/> to let a paused <see cref="SetAsync"/> finish.
+    /// </summary>
+    private TaskCompletionSource? _setReleased;
+
+    /// <summary>
+    /// The <c>expires</c> argument of the most recent <see cref="SetAsync"/> call — lets a test assert the
+    /// physical TTL the cache computed (e.g. the near-immediate-expiry clamp) instead of trusting a round-trip.
+    /// </summary>
+    public Duration LastSetExpires { get; private set; }
+
+    /// <summary>
+    /// Returns all stored keys (the <paramref name="pattern"/> is ignored — the cache does not enumerate keys).
+    /// </summary>
+    /// <param name="pattern">Ignored.</param>
+    /// <param name="ct">Cancellation token (unused).</param>
+    /// <returns>A snapshot of all stored keys.</returns>
+    public Task<IReadOnlyCollection<string>> GetKeysAsync(string pattern = "", CancellationToken ct = default) =>
+        Task.FromResult<IReadOnlyCollection<string>>(_data.Keys.ToArray());
+
+    /// <summary>
+    /// Retrieves the stored value for a key.
+    /// </summary>
+    /// <param name="key">The key to read.</param>
+    /// <param name="ct">Cancellation token (unused).</param>
+    /// <returns>The value if present, otherwise null.</returns>
+    public Task<string?> GetAsync(string key, CancellationToken ct = default) =>
+        Task.FromResult(_data.TryGetValue(key, out var v) ? v : null);
+
+    /// <summary>
+    /// Stores a value for a key. When the gate is armed (see <see cref="ArmSetGate"/>), the call signals it and
+    /// blocks until <see cref="ReleaseSet"/> before writing; <see cref="LastSetExpires"/> records the ttl.
+    /// </summary>
+    /// <param name="key">The key to set.</param>
+    /// <param name="value">The value to store.</param>
+    /// <param name="expires">The requested physical TTL (recorded into <see cref="LastSetExpires"/>, not enforced).</param>
+    /// <param name="ct">Cancellation token (unused).</param>
+    /// <returns>Always true.</returns>
+    public async Task<bool> SetAsync(
+        string key,
+        string value,
+        Duration expires = default,
+        CancellationToken ct = default
+    )
+    {
+        LastSetExpires = expires;
+
+        var entered = _setEntered;
+        if (entered is not null)
+        {
+            // one-shot: disarm entry so the released write (and any later write) is not re-gated; keep
+            // _setReleased non-null so ReleaseSet can still signal the captured completion source below.
+            var released = _setReleased!;
+            _setEntered = null;
+            entered.TrySetResult();
+            await released.Task;
+        }
+
+        _data[key] = value;
+        return true;
+    }
+
+    /// <summary>
+    /// Deletes a key.
+    /// </summary>
+    /// <param name="key">The key to delete.</param>
+    /// <param name="ct">Cancellation token (unused).</param>
+    /// <returns>True if the key existed and was removed, otherwise false.</returns>
+    public Task<bool> DeleteAsync(string key, CancellationToken ct = default) =>
+        Task.FromResult(_data.TryRemove(key, out _));
+
+    /// <summary>
+    /// Arms a one-shot gate: the next <see cref="SetAsync"/> signals the returned task, then blocks until
+    /// <see cref="ReleaseSet"/> is called.
+    /// </summary>
+    /// <returns>A task that completes when the next <see cref="SetAsync"/> has entered and paused.</returns>
+    public Task ArmSetGate()
+    {
+        _setEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _setReleased = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        return _setEntered.Task;
+    }
+
+    /// <summary>
+    /// Releases the armed <see cref="SetAsync"/> so it completes its write.
+    /// </summary>
+    public void ReleaseSet() => _setReleased?.TrySetResult();
+
+    /// <summary>
+    /// Whether the backing store currently holds the given key.
+    /// </summary>
+    /// <param name="key">The (prefixed) storage key.</param>
+    /// <returns><c>true</c> if present.</returns>
+    public bool Has(string key) => _data.ContainsKey(key);
+}

--- a/base/Cache/tests/Annium.Cache.Redis.Tests/RaceTests.cs
+++ b/base/Cache/tests/Annium.Cache.Redis.Tests/RaceTests.cs
@@ -1,0 +1,228 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Annium.Cache.Abstractions;
+using Annium.Core.Runtime.Time;
+using Annium.Redis;
+using Annium.Testing;
+using NodaTime;
+using Xunit;
+
+namespace Annium.Cache.Redis.Tests;
+
+/// <summary>
+/// Redis-cache storage-timing race tests over a gated in-process <see cref="IRedisStorage"/> double
+/// (<see cref="GatedRedisStorage"/>), which lets a concurrent <c>RemoveAsync</c> be interleaved with an
+/// in-flight write at an exact point — impossible against a real Testcontainers backend that cannot pause
+/// between a GET and a SET.
+/// </summary>
+public class RaceTests : TestBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RaceTests"/> class.
+    /// </summary>
+    /// <param name="outputHelper">The test output helper for logging test information.</param>
+    public RaceTests(ITestOutputHelper outputHelper)
+        : base(outputHelper)
+    {
+        RegisterServicePack<FakeStorageServicePack>();
+    }
+
+    /// <summary>
+    /// Verifies the sliding-refresh-vs-remove race: if a <c>RemoveAsync</c> lands while a live sliding entry's
+    /// prolongation SET is in flight, the remove must still win — the refreshed entry must not resurrect the key.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task GetOrCreateAsync_SlidingRefreshRacesRemove_KeyStaysDeleted()
+    {
+        // arrange
+        var ct = TestContext.Current.CancellationToken;
+        Get<ITimeProviderSwitcher>().UseManagedTime();
+        Get<ITimeManager>().SetNow(SystemClock.Instance.GetCurrentInstant());
+        var cache = Get<ICache<Guid, string>>();
+        var storage = (GatedRedisStorage)Get<IRedisStorage>();
+        var key = Guid.NewGuid();
+        var prefixed = RedisTestKeys.Prefixed<string>(key);
+        var options = CacheOptions.WithSlidingExpiration(Duration.FromMinutes(1));
+
+        var factoryCalls = 0;
+        ValueTask<string> Factory(Guid k, CancellationToken token)
+        {
+            factoryCalls++;
+
+            return ValueTask.FromResult("v");
+        }
+
+        // seed a live sliding entry by letting the cache create it (ungated)
+        (await cache.GetOrCreateAsync(key, Factory, options, ct)).Is("v");
+        storage.Has(prefixed).IsTrue();
+
+        // arm the gate so the NEXT SET (the sliding-refresh prolongation) pauses mid-flight
+        var refreshEntered = storage.ArmSetGate();
+
+        // act: hit the live entry — the winner reads (hit) then starts the sliding-refresh SET, which now pauses
+        var getTask = cache.GetOrCreateAsync(key, Factory, options, ct).AsTask();
+        await refreshEntered.WaitAsync(TimeSpan.FromSeconds(5), ct);
+
+        // a concurrent remove lands while the refresh SET is paused
+        await cache.RemoveAsync(key, ct);
+
+        // release the paused refresh SET (it would resurrect the key); the invalidation guard must delete it again
+        storage.ReleaseSet();
+        // getTask is created locally above via .AsTask(); awaiting it here is safe (not a foreign task)
+#pragma warning disable VSTHRD003
+        (await getTask.WaitAsync(TimeSpan.FromSeconds(5), ct)).Is("v");
+#pragma warning restore VSTHRD003
+
+        // assert: the remove wins — the key does not survive the refresh; the second call was a hit (no factory)
+        storage.Has(prefixed).IsFalse();
+        factoryCalls.Is(1);
+    }
+
+    /// <summary>
+    /// Verifies the post-write invalidation compensating delete: if a <c>RemoveAsync</c> lands after the
+    /// pre-write invalidation check but before the create-path SET completes, the just-written entry is
+    /// compensating-deleted so the remove is not lost.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task GetOrCreateAsync_PostWriteInvalidation_CompensatingDeleteRemovesEntry()
+    {
+        // arrange
+        var ct = TestContext.Current.CancellationToken;
+        Get<ITimeProviderSwitcher>().UseManagedTime();
+        Get<ITimeManager>().SetNow(SystemClock.Instance.GetCurrentInstant());
+        var cache = Get<ICache<Guid, string>>();
+        var storage = (GatedRedisStorage)Get<IRedisStorage>();
+        var key = Guid.NewGuid();
+        var prefixed = RedisTestKeys.Prefixed<string>(key);
+        var options = CacheOptions.WithSlidingExpiration(Duration.FromMinutes(1));
+
+        // arm the gate so the create-path SET pauses AFTER the factory produces, BEFORE the write lands
+        var setEntered = storage.ArmSetGate();
+
+        // act: miss → factory → SET (paused)
+        var getTask = cache.GetOrCreateAsync(key, static (_, _) => ValueTask.FromResult("v"), options, ct).AsTask();
+        await setEntered.WaitAsync(TimeSpan.FromSeconds(5), ct);
+
+        // remove lands after the pre-write invalidation check but before the SET completes
+        await cache.RemoveAsync(key, ct);
+
+        // release the create SET (writes the entry); the post-write guard must compensating-delete it
+        storage.ReleaseSet();
+        // getTask is created locally above via .AsTask(); awaiting it here is safe (not a foreign task)
+#pragma warning disable VSTHRD003
+        (await getTask.WaitAsync(TimeSpan.FromSeconds(5), ct)).Is("v");
+#pragma warning restore VSTHRD003
+
+        // assert: the entry is purged despite the write landing after the remove
+        storage.Has(prefixed).IsFalse();
+    }
+
+    /// <summary>
+    /// Verifies the physical-TTL clamp: an absolute expiration at "now" yields a non-positive raw TTL that must
+    /// be clamped to a small POSITIVE duration before hitting storage — never <see cref="Duration.Zero"/>, which
+    /// the real backend maps to "no expiration" (a leaked never-expiring key). Asserts the ttl actually passed to
+    /// storage, so removing the clamp fails the test (logical expiry alone would not catch it).
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task GetOrCreateAsync_AbsoluteExpirationAtNow_ClampsPhysicalTtlToPositive()
+    {
+        // arrange
+        var ct = TestContext.Current.CancellationToken;
+        Get<ITimeProviderSwitcher>().UseManagedTime();
+        Get<ITimeManager>().SetNow(SystemClock.Instance.GetCurrentInstant());
+        var timeProvider = Get<ITimeProvider>();
+        var cache = Get<ICache<Guid, string>>();
+        var storage = (GatedRedisStorage)Get<IRedisStorage>();
+        var key = Guid.NewGuid();
+
+        var calls = 0;
+        ValueTask<string> Factory(Guid k, CancellationToken token)
+        {
+            Interlocked.Increment(ref calls);
+
+            return ValueTask.FromResult("v");
+        }
+
+        // act: absolute expiration AT now → GetExpiresAt(now) == now → raw ttl == 0 → must be clamped to 1ms
+        var options = CacheOptions.WithAbsoluteExpiration(timeProvider.Now);
+        (await cache.GetOrCreateAsync(key, Factory, options, ct)).Is("v");
+
+        // assert: the physical ttl the cache sent to storage is a small positive duration, never Zero/negative
+        (storage.LastSetExpires > Duration.Zero).IsTrue();
+        storage.LastSetExpires.Is(Duration.FromMilliseconds(1));
+
+        // and: logically expired immediately (now >= ExpiresAtMs) → next call re-invokes the factory
+        (await cache.GetOrCreateAsync(key, Factory, options, ct)).Is("v");
+        calls.Is(2);
+    }
+
+    /// <summary>
+    /// Verifies the value-type discriminator prevents cross-type key collision: two distinct closed generics
+    /// (<c>ICache&lt;Guid,string&gt;</c> and <c>ICache&lt;Guid,int&gt;</c>) resolved from one registration and
+    /// sharing a single Redis store must not collide on an identical key value — each keeps its own value, and a
+    /// remove on one value-type does not evict the other. A regression that dropped the discriminator would fail
+    /// this (both would map to <c>test:{guid}</c>).
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task GetOrCreateAsync_DistinctValueTypesSameKey_DoNotCollide()
+    {
+        // arrange
+        var ct = TestContext.Current.CancellationToken;
+        Get<ITimeProviderSwitcher>().UseManagedTime();
+        Get<ITimeManager>().SetNow(SystemClock.Instance.GetCurrentInstant());
+        var strings = Get<ICache<Guid, string>>();
+        var ints = Get<ICache<Guid, int>>();
+        var options = CacheOptions.WithSlidingExpiration(Duration.FromMinutes(1));
+        var key = Guid.NewGuid();
+
+        // act: same TKey value, two different TValue caches over one shared store
+        (await strings.GetOrCreateAsync(key, static (_, _) => ValueTask.FromResult("v"), options, ct)).Is("v");
+        (await ints.GetOrCreateAsync(key, static (_, _) => ValueTask.FromResult(42), options, ct)).Is(42);
+
+        // assert: no collision — each cache still returns its own value (factory must not re-run on a hit)
+        (await strings.GetOrCreateAsync(key, static (_, _) => ValueTask.FromResult("other"), options, ct)).Is("v");
+        (await ints.GetOrCreateAsync(key, static (_, _) => ValueTask.FromResult(-1), options, ct)).Is(42);
+
+        // and: removing one value-type's entry does not evict the other's
+        await ints.RemoveAsync(key, ct);
+        (await strings.GetOrCreateAsync(key, static (_, _) => ValueTask.FromResult("other"), options, ct)).Is("v");
+    }
+
+    /// <summary>
+    /// Verifies the physical-TTL leak-guard for the ordinary (positive remaining-lifetime) case: the ttl the
+    /// cache sends to storage equals the full remaining lifetime (expiresAt - now), not the near-immediate 1ms
+    /// clamp. Guards against a regression that always clamps or computes the ttl with the wrong operands/sign
+    /// (which would leak every key with a 1ms TTL) — invisible to logical-expiry-only assertions.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task GetOrCreateAsync_PositiveLifetime_SetsPhysicalTtlToRemainingLifetime()
+    {
+        // arrange
+        var ct = TestContext.Current.CancellationToken;
+        Get<ITimeProviderSwitcher>().UseManagedTime();
+        Get<ITimeManager>().SetNow(SystemClock.Instance.GetCurrentInstant());
+        var cache = Get<ICache<Guid, string>>();
+        var storage = (GatedRedisStorage)Get<IRedisStorage>();
+        var key = Guid.NewGuid();
+        var lifetime = Duration.FromMinutes(1);
+
+        // act: sliding 60s at fixed managed now → expiresAt = now + 60s → physical ttl == 60s (no clamp)
+        (
+            await cache.GetOrCreateAsync(
+                key,
+                static (_, _) => ValueTask.FromResult("v"),
+                CacheOptions.WithSlidingExpiration(lifetime),
+                ct
+            )
+        ).Is("v");
+
+        // assert: the leak-guard ttl carries the full remaining lifetime, not the degenerate 1ms clamp
+        storage.LastSetExpires.Is(lifetime);
+    }
+}

--- a/base/Cache/tests/Annium.Cache.Redis.Tests/RedisTestKeys.cs
+++ b/base/Cache/tests/Annium.Cache.Redis.Tests/RedisTestKeys.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Annium.Cache.Redis.Tests;
+
+/// <summary>
+/// Helpers for reconstructing the storage keys the Redis cache derives, for white-box assertions that peek at
+/// the backing store directly.
+/// </summary>
+internal static class RedisTestKeys
+{
+    /// <summary>
+    /// Reconstructs the storage key the cache derives for a <c>"test:"</c>-prefixed <c>ICache&lt;Guid,TValue&gt;</c>:
+    /// the configured prefix + the value-type discriminator + the key. Mirrors <c>Cache.Key()</c> so a test can
+    /// assert the exact stored key without hard-coding the formula at each call site.
+    /// </summary>
+    /// <typeparam name="TValue">The cache value type whose discriminator is folded into the key.</typeparam>
+    /// <param name="key">The cache key.</param>
+    /// <returns>The prefixed, value-type-scoped storage key.</returns>
+    public static string Prefixed<TValue>(Guid key) => $"test:{typeof(TValue).FullName}:{key}";
+}

--- a/base/Cache/tests/Annium.Cache.Redis.Tests/ServicePack.cs
+++ b/base/Cache/tests/Annium.Cache.Redis.Tests/ServicePack.cs
@@ -2,11 +2,15 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Annium.Core.DependencyInjection;
+using Annium.Redis;
+using Annium.Serialization.Abstractions;
+using Annium.Serialization.Json;
 
 namespace Annium.Cache.Redis.Tests;
 
 /// <summary>
-/// Service pack for configuring Redis cache dependencies for testing.
+/// Service pack for configuring Redis cache dependencies for testing: a JSON serializer, a Testcontainers
+/// Redis backend, the shared <c>IRedisStorage</c> (via <c>AddRedis</c>), and the cache itself.
 /// </summary>
 public class ServicePack : ServicePackBase
 {
@@ -19,7 +23,22 @@ public class ServicePack : ServicePackBase
     /// <returns>A task that represents the asynchronous registration.</returns>
     public override Task RegisterAsync(IServiceContainer container, IServiceProvider provider, CancellationToken ct)
     {
-        container.AddRedisCache(ServiceLifetime.Singleton);
+        container.AddSerializers().WithJson(isDefault: true);
+        container.Add<Database>().AsSelf().Singleton();
+        container.Add(sp => sp.Resolve<Database>().Config).AsSelf().Singleton();
+        container.AddRedis();
+        container.AddRedisCache(cfg => cfg.KeyPrefix = "test:");
         return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Sets up the test environment by initializing the Redis database container.
+    /// </summary>
+    /// <param name="provider">The service provider for resolving dependencies.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A task that represents the asynchronous setup.</returns>
+    public override async Task SetupAsync(IServiceProvider provider, CancellationToken ct)
+    {
+        await provider.Resolve<Database>().InitAsync();
     }
 }

--- a/base/Cache/tests/Annium.Cache.Tests.Lib/CacheTestsBase.cs
+++ b/base/Cache/tests/Annium.Cache.Tests.Lib/CacheTestsBase.cs
@@ -377,10 +377,10 @@ public class CacheTestsBase : TestBase
         timeManager.SetNow(timeProvider.Now + Duration.FromSeconds(30));
         var third = await cache.GetOrCreateAsync(key, GetPageAsync, options, ct);
 
-        // assert: the item survived via prolongation — factory ran exactly once, same instance throughout
+        // assert: the item survived via prolongation — factory ran exactly once, same cached entry throughout
         _factoryCounter.Is(1);
-        ReferenceEquals(second, first).IsTrue();
-        ReferenceEquals(third, first).IsTrue();
+        AssertCachedInstance(second, first);
+        AssertCachedInstance(third, first);
     }
 
     /// <summary>
@@ -411,16 +411,18 @@ public class CacheTestsBase : TestBase
         timeManager.SetNow(timeProvider.Now + Duration.FromSeconds(30));
         var third = await cache.GetOrCreateAsync(key, GetPageAsync, shortOptions, ct);
 
-        // assert: not evicted by the later caller's 1s window — factory ran once, same instance
+        // assert: not evicted by the later caller's 1s window — factory ran once, same cached entry
         _factoryCounter.Is(1);
-        ReferenceEquals(second, first).IsTrue();
-        ReferenceEquals(third, first).IsTrue();
+        AssertCachedInstance(second, first);
+        AssertCachedInstance(third, first);
     }
 
     /// <summary>
     /// Verifies the post-factory expiry guard: when a slow factory completes AFTER its entry has expired,
     /// the cache discards the result (TrySetCanceled) and evicts the entry so a later call recreates it.
     /// </summary>
+    /// <remarks>⚠ InMemory-only: asserts the in-process TCS/executor expiry-race mechanics; not applicable to a
+    /// distributed backend (Redis) whose expiry is server-side and single-flight is in-process. Do NOT wire as a Redis [Fact].</remarks>
     /// <returns>A task that represents the asynchronous test operation</returns>
     protected async Task GetOrCreateAsync_FactoryCompletesAfterExpiry_CancelsAndEvicts_Base()
     {
@@ -583,6 +585,8 @@ public class CacheTestsBase : TestBase
     /// Verifies the expiry-path eviction is identity-guarded: a slow factory that completes AFTER its entry
     /// expired AND after a replacement entry was created for the same key must NOT evict the replacement.
     /// </summary>
+    /// <remarks>⚠ InMemory-only: asserts identity-guarded eviction of an in-process entry; not applicable to a
+    /// distributed backend (Redis). Do NOT wire as a Redis [Fact].</remarks>
     /// <returns>A task that represents the asynchronous test operation</returns>
     protected async Task GetOrCreateAsync_ExpiredFactoryAfterReplacement_ReplacementSurvives_Base()
     {
@@ -630,6 +634,8 @@ public class CacheTestsBase : TestBase
     /// Verifies the exception-path eviction is identity-guarded: a factory that throws AFTER its entry was
     /// removed and a replacement created for the same key must NOT evict the replacement.
     /// </summary>
+    /// <remarks>⚠ InMemory-only: asserts identity-guarded eviction of an in-process entry; not applicable to a
+    /// distributed backend (Redis). Do NOT wire as a Redis [Fact].</remarks>
     /// <returns>A task that represents the asynchronous test operation</returns>
     protected async Task GetOrCreateAsync_ThrowingFactoryAfterReplacement_ReplacementSurvives_Base()
     {
@@ -694,7 +700,19 @@ public class CacheTestsBase : TestBase
     }
 
     /// <summary>
-    /// Validates that the cached items meet expected criteria including factory call count, item count, and reference equality.
+    /// Asserts that two cached items returned for the same key represent the same cached entry.
+    /// Default: value-equality — a distributed backend (Redis) deserializes a fresh instance per read,
+    /// so identity cannot hold. The InMemory suite overrides this with <c>ReferenceEquals</c> because its
+    /// contract is one shared instance per key.
+    /// </summary>
+    /// <typeparam name="T">The reference type of the cached items.</typeparam>
+    /// <param name="actual">The item under test.</param>
+    /// <param name="expected">The reference item to compare against.</param>
+    protected virtual void AssertCachedInstance<T>(T actual, T expected)
+        where T : class => actual.Is(expected);
+
+    /// <summary>
+    /// Validates that the cached items meet expected criteria including factory call count, item count, and equality.
     /// </summary>
     /// <param name="counter">The expected number of times the factory method should have been called.</param>
     /// <param name="key">The cache key used for item creation.</param>
@@ -706,7 +724,7 @@ public class CacheTestsBase : TestBase
         items.Has(count);
         items[0].Is(new Page(key));
         foreach (var item in items)
-            ReferenceEquals(item, items[0]).IsTrue();
+            AssertCachedInstance(item, items[0]);
     }
 
     /// <summary>

--- a/base/Cache/tests/Annium.Cache.Tests.Lib/CacheTestsBase.cs
+++ b/base/Cache/tests/Annium.Cache.Tests.Lib/CacheTestsBase.cs
@@ -748,12 +748,18 @@ public class CacheTestsBase : TestBase
         /// <summary>
         /// Gets the title of the page.
         /// </summary>
-        public string Title { get; }
+        public string Title { get; init; } = string.Empty;
 
         /// <summary>
         /// Gets the content of the page.
         /// </summary>
-        public string Content { get; }
+        public string Content { get; init; } = string.Empty;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Page"/> record. Parameterless ctor enables
+        /// serializer round-tripping (Redis) via the init properties.
+        /// </summary>
+        public Page() { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Page"/> record.


### PR DESCRIPTION
…edisStorage

- build the Redis cache on IRedisStorage (no direct StackExchange.Redis / duplicated connection)
- RedisCacheOptions (KeyPrefix); AddRedisCache(Action<RedisCacheOptions>?, lifetime)
- implement RemoveAsync via storage.DeleteAsync; DisposeAsync idempotent no-op
- Testcontainers harness (AddRedis + JSON serializer + AddRedisCache)
- 3 tests green, 4 GetOrCreate/Remove scenarios skipped for later tasks